### PR TITLE
Attribute configuration and dataset specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   - [#218](https://github.com/Datatamer/unify-client-python/issues/218) Delete a `BaseResource`
   - [#233](https://github.com/Datatamer/unify-client-python/issues/233) Remove an input dataset from a project
   - [#67](https://github.com/Datatamer/unify-client-python/issues/67) Create a dataset from a pandas `DataFrame`
+  - [#222](https://github.com/Datatamer/unify-client-python/issues/222) Dataset spec to update an existing dataset
+  - [#225](https://github.com/Datatamer/unify-client-python/issues/225) Attribute configuration spec to update an existing attribute configuration
 
   **BUG FIXES**
   - [#235](https://github.com/Datatamer/unify-client-python/issues/235) Making `AttributeCollection` retrieve attributes directly instead of by streaming

--- a/docs/developer-interface.rst
+++ b/docs/developer-interface.rst
@@ -78,6 +78,12 @@ Dataset
 .. autoclass:: tamr_unify_client.dataset.resource.Dataset
   :members:
 
+Dataset Spec
+^^^^^^^^^^^^
+
+.. autoclass:: tamr_unify_client.dataset.resource.DatasetSpec
+  :members:
+
 Dataset Collection
 ^^^^^^^^^^^^^^^^^^
 
@@ -198,6 +204,12 @@ Attribute Configuration
 """""""""""""""""""""""
 
 .. autoclass:: tamr_unify_client.project.attribute_configuration.resource.AttributeConfiguration
+  :members:
+
+Attribute Configuration Spec
+""""""""""""""""""""""""""""
+
+.. autoclass:: tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec
   :members:
 
 Attribute Configuration Collection

--- a/tamr_unify_client/project/attribute_configuration/resource.py
+++ b/tamr_unify_client/project/attribute_configuration/resource.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from tamr_unify_client.base_resource import BaseResource
 
 
@@ -58,6 +60,14 @@ class AttributeConfiguration(BaseResource):
         """:type: str"""
         return self._data.get("attributeName")
 
+    def spec(self):
+        """Returns this attribute configuration's spec.
+
+         :return: The spec of this attribute configuration.
+         :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+         """
+        return AttributeConfigurationSpec.of(self)
+
     def __repr__(self):
         return (
             f"{self.__class__.__module__}."
@@ -71,4 +81,122 @@ class AttributeConfiguration(BaseResource):
             f"tokenizer={self.tokenizer!r}, "
             f"numeric_field_resolution={self.numeric_field_resolution!r}, "
             f"attribute_name={self.attribute_name!r})"
+        )
+
+
+class AttributeConfigurationSpec:
+    """A representation of the server view of an attribute configuration."""
+
+    def __init__(self, client, data, api_path):
+        self.client = client
+        self._data = data
+        self.api_path = api_path
+
+    @staticmethod
+    def of(resource):
+        """Creates an attribute configuration spec from an attribute configuration.
+
+        :param resource: The existing attribute configuration.
+        :type resource: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfiguration`
+        :return: The corresponding attribute creation spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return AttributeConfigurationSpec(
+            resource.client, deepcopy(resource._data), resource.api_path
+        )
+
+    def from_data(self, data):
+        """Creates a spec with the same client and API path as this one, but new data.
+
+        :param data: The data for the new spec.
+        :type data: dict
+        :return: The new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return AttributeConfigurationSpec(self.client, data, self.api_path)
+
+    def to_dict(self):
+        """Returns a version of this spec that conforms to the API representation.
+
+        :returns: The spec's dict.
+        :rtype: dict
+        """
+        return deepcopy(self._data)
+
+    def with_attribute_role(self, new_attribute_role):
+        """Creates a new spec with the same properties, updating attribute role.
+
+        :param new_attribute_role: The new attribute role.
+        :type new_attribute_role: str
+        :return: A new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return self.from_data({**self._data, "attributeRole": new_attribute_role})
+
+    def with_similarity_function(self, new_similarity_function):
+        """Creates a new spec with the same properties, updating similarity function.
+
+        :param new_similarity_function: The new similarity function.
+        :type new_similarity_function: str
+        :return: A new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return self.from_data(
+            {**self._data, "similarityFunction": new_similarity_function}
+        )
+
+    def with_enabled_for_ml(self, new_enabled_for_ml):
+        """Creates a new spec with the same properties, updating enabled for ML.
+
+        :param new_enabled_for_ml: Whether the builder is enabled for ML.
+        :type new_enabled_for_ml: bool
+        :return: A new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return self.from_data({**self._data, "enabledForMl": new_enabled_for_ml})
+
+    def with_tokenizer(self, new_tokenizer):
+        """Creates a new spec with the same properties, updating tokenizer.
+
+        :param new_tokenizer: The new tokenizer.
+        :type new_tokenizer: str
+        :return: A new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return self.from_data({**self._data, "tokenizer": new_tokenizer})
+
+    def with_numeric_field_resolution(self, new_numeric_field_resolution):
+        """Creates a new spec with the same properties, updating numeric field resolution.
+
+        :param new_numeric_field_resolution: The new numeric field resolution.
+        :type new_numeric_field_resolution: str
+        :return: A new spec.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfigurationSpec`
+        """
+        return self.from_data(
+            {**self._data, "numericFieldResolution": new_numeric_field_resolution}
+        )
+
+    def put(self):
+        """Updates the attribute configuration on the server.
+
+        :return: The modified attribute configuration.
+        :rtype: :class:`~tamr_unify_client.project.attribute_configuration.resource.AttributeConfiguration`
+        """
+        new_data = self.client.put(self.api_path, json=self._data).successful().json()
+        return AttributeConfiguration.from_json(self.client, new_data, self.api_path)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"relative_id={self._data['relativeId']!r}, "
+            f"id={self._data['id']!r}, "
+            f"relative_attribute_id={self._data['relativeAttributeId']!r}, "
+            f"attribute_role={self._data['attributeRole']!r}, "
+            f"similarity_function={self._data['similarityFunction']!r}, "
+            f"enabled_for_ml={self._data['enabledForMl']!r}, "
+            f"tokenizer={self._data['tokenizer']!r}, "
+            f"numeric_field_resolution={self._data['numericFieldResolution']!r}, "
+            f"attribute_name={self._data['attributeName']!r})"
         )

--- a/tests/unit/test_attribute_configuration.py
+++ b/tests/unit/test_attribute_configuration.py
@@ -1,3 +1,5 @@
+from functools import partial
+import json
 from unittest import TestCase
 
 from requests import HTTPError
@@ -57,22 +59,57 @@ class TestAttributeConfiguration(TestCase):
 
     @responses.activate
     def test_delete(self):
-        base = "http://localhost:9100/api/versioned/v1"
-        alias = "projects/1/attributeConfigurations"
-        attribute_id = "26"
-
-        url = f"{base}/{alias}/{attribute_id}"
+        url = f"{self._base}/{self._alias}/{self._attribute_id}"
         responses.add(responses.GET, url, json=self._ac_json)
         responses.add(responses.DELETE, url, status=204)
         responses.add(responses.GET, url, status=404)
 
-        collection = AttributeConfigurationCollection(self.tamr, alias)
-        config = collection.by_resource_id(attribute_id)
+        collection = AttributeConfigurationCollection(self.tamr, self._alias)
+        config = collection.by_resource_id(self._attribute_id)
+
         self.assertEqual(config._data, self._ac_json)
 
         response = config.delete()
         self.assertEqual(response.status_code, 204)
-        self.assertRaises(HTTPError, lambda: collection.by_resource_id(attribute_id))
+        self.assertRaises(
+            HTTPError, lambda: collection.by_resource_id(self._attribute_id)
+        )
+
+    @responses.activate
+    def test_update(self):
+        def create_callback(request, snoop):
+            snoop["payload"] = request.body
+            return 200, {}, json.dumps(self._updated_ac_json)
+
+        configs_url = f"{self._base}/{self._alias}"
+        config_url = f"{configs_url}/{self._attribute_id}"
+
+        snoop_dict = {}
+        responses.add(responses.GET, config_url, json=self._ac_json)
+        responses.add_callback(
+            responses.PUT, config_url, partial(create_callback, snoop=snoop_dict)
+        )
+        configs = AttributeConfigurationCollection(self.tamr, self._alias)
+        config = configs.by_resource_id(self._attribute_id)
+
+        temp_spec = config.spec().with_attribute_role("SUM_ATTRIBUTE")
+        new_config = (
+            temp_spec.with_enabled_for_ml(False)
+            .with_similarity_function("ABSOLUTE_DIFF")
+            .with_tokenizer("BIGRAM")
+            .put()
+        )
+
+        self.assertEqual(new_config._data, self._updated_ac_json)
+        self.assertEqual(json.loads(snoop_dict["payload"]), self._updated_ac_json)
+        self.assertEqual(config._data, self._ac_json)
+
+        # checking that intermediate didn't change
+        self.assertTrue(temp_spec.to_dict()["enabledForMl"])
+
+    _base = "http://localhost:9100/api/versioned/v1"
+    _alias = "projects/1/attributeConfigurations"
+    _attribute_id = "26"
 
     _ac_json = {
         "id": "unify://unified-data/v1/projects/1/attributeConfigurations/26",
@@ -82,6 +119,18 @@ class TestAttributeConfiguration(TestCase):
         "similarityFunction": "COSINE",
         "enabledForMl": True,
         "tokenizer": "DEFAULT",
+        "numericFieldResolution": [],
+        "attributeName": "surname",
+    }
+
+    _updated_ac_json = {
+        "id": "unify://unified-data/v1/projects/1/attributeConfigurations/26",
+        "relativeId": "projects/1/attributeConfigurations/26",
+        "relativeAttributeId": "datasets/8/attributes/surname",
+        "attributeRole": "SUM_ATTRIBUTE",
+        "similarityFunction": "ABSOLUTE_DIFF",
+        "enabledForMl": False,
+        "tokenizer": "BIGRAM",
         "numericFieldResolution": [],
         "attributeName": "surname",
     }

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,3 +1,5 @@
+from functools import partial
+import json
 from unittest import TestCase
 
 from requests import HTTPError
@@ -14,10 +16,9 @@ class TestAttribute(TestCase):
 
     @responses.activate
     def test_delete(self):
-        url = "http://localhost:9100/api/versioned/v1/datasets/1"
-        responses.add(responses.GET, url, json=self._dataset_json)
-        responses.add(responses.DELETE, url, status=204)
-        responses.add(responses.GET, url, status=404)
+        responses.add(responses.GET, self._url, json=self._dataset_json)
+        responses.add(responses.DELETE, self._url, status=204)
+        responses.add(responses.GET, self._url, status=404)
 
         dataset = self.tamr.datasets.by_resource_id("1")
         self.assertEqual(dataset._data, self._dataset_json)
@@ -25,6 +26,40 @@ class TestAttribute(TestCase):
         response = dataset.delete()
         self.assertEqual(response.status_code, 204)
         self.assertRaises(HTTPError, lambda: self.tamr.datasets.by_resource_id("1"))
+
+    @responses.activate
+    def test_update(self):
+        def create_callback(request, snoop):
+            snoop["payload"] = request.body
+            return 200, {}, json.dumps(self._updated_dataset_json)
+
+        snoop_dict = {}
+        responses.add(responses.GET, self._url, json=self._dataset_json)
+        responses.add_callback(
+            responses.PUT, self._url, partial(create_callback, snoop=snoop_dict)
+        )
+
+        dataset = self.tamr.datasets.by_resource_id("1")
+
+        temp_spec = dataset.spec().with_description(
+            self._updated_dataset_json["description"]
+        )
+        new_dataset = (
+            temp_spec.with_external_id(self._updated_dataset_json["externalId"])
+            .with_tags(self._updated_dataset_json["tags"])
+            .put()
+        )
+
+        self.assertEqual(new_dataset._data, self._updated_dataset_json)
+        self.assertEqual(json.loads(snoop_dict["payload"]), self._updated_dataset_json)
+        self.assertEqual(dataset._data, self._dataset_json)
+
+        # checking that intermediate didn't change
+        self.assertEqual(
+            temp_spec.to_dict()["externalId"], self._dataset_json["externalId"]
+        )
+
+    _url = "http://localhost:9100/api/versioned/v1/datasets/1"
 
     _dataset_json = {
         "id": "unify://unified-data/v1/datasets/1",
@@ -34,6 +69,28 @@ class TestAttribute(TestCase):
         "version": "dataset 1 version",
         "keyAttributeNames": ["tamr_id"],
         "tags": [],
+        "created": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.636Z",
+            "version": "dataset 1 created version",
+        },
+        "lastModified": {
+            "username": "admin",
+            "time": "2018-09-10T16:06:20.851Z",
+            "version": "dataset 1 modified version",
+        },
+        "relativeId": "datasets/1",
+        "upstreamDatasetIds": [],
+    }
+
+    _updated_dataset_json = {
+        "id": "unify://unified-data/v1/datasets/1",
+        "externalId": "dataset1",
+        "name": "dataset 1 name",
+        "description": "updated description",
+        "version": "dataset 1 version",
+        "keyAttributeNames": ["tamr_id"],
+        "tags": ["new", "tags"],
         "created": {
             "username": "admin",
             "time": "2018-09-10T16:06:20.636Z",


### PR DESCRIPTION
# ↪️ Pull Request

An option for #252 

Fix #222 
Fix #225 

## 💻 Examples

```
from tamr_unify_client import Client
from tamr_unify_client.auth import UsernamePasswordAuth

unify = Client(UsernamePasswordAuth("username", "password"), "ip")
p = unify.projects.by_resource_id("1")
configs = p.attribute_configurations()

keep_ml = ["email", "last", "zip"]

for config in configs:
    if config.attribute_name not in keep_ml:
        config.spec().with_enabled_for_ml(False).put()
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
