### PR TITLE
Published clusters configuration put

### DIFF
--- a/tamr_unify_client/mastering/published_cluster/configuration.py
+++ b/tamr_unify_client/mastering/published_cluster/configuration.py
@@ -38,11 +38,12 @@ class PublishedClustersConfiguration(BaseResource):
         return self._data.get("versionsTimeToLive")
 
     def spec(self):
-        """Returns a spec representation of this published cluster
+        """Returns a spec representation of this published cluster configuration.
 
-        :return: the published cluster spec
-        :rtype: :class`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClusterConfigurationSpec"""
-        return PublishedClusterConfigurationSpec.of(self)
+        :return: The published cluster configuration spec.
+        :rtype: :class`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfigurationSpec`
+        """
+        return PublishedClustersConfigurationSpec.of(self)
 
     def __repr__(self):
         return (
@@ -53,8 +54,8 @@ class PublishedClustersConfiguration(BaseResource):
         )
 
 
-class PublishedClusterConfigurationSpec:
-    """A representation of the server view of a published cluster."""
+class PublishedClustersConfigurationSpec:
+    """A representation of the server view of published clusters configuration."""
 
     def __init__(self, client, data, api_path):
         self.client = client
@@ -63,14 +64,14 @@ class PublishedClusterConfigurationSpec:
 
     @staticmethod
     def of(resource):
-        """Creates an published cluster spec from published cluster.
+        """Creates an published cluster configuration spec from published cluster configuration.
 
-        :param resource: The existing published cluster.
-        :type resource: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClusterConfiguration`
-        :return: The corresponding published cluster spec.
-        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClusterConfigurationSpec`
+        :param resource: The existing published cluster configuration.
+        :type resource: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfiguration`
+        :return: The corresponding published cluster configuration spec.
+        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfigurationSpec`
         """
-        return PublishedClusterConfigurationSpec(
+        return PublishedClustersConfigurationSpec(
             resource.client, deepcopy(resource._data), resource.api_path
         )
 
@@ -80,9 +81,9 @@ class PublishedClusterConfigurationSpec:
         :param data: The data for the new spec.
         :type data: dict
         :return: The new spec.
-        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClusterConfigurationSpec`
+        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfigurationSpec`
         """
-        return PublishedClusterConfigurationSpec(self.client, data, self.api_path)
+        return PublishedClustersConfigurationSpec(self.client, data, self.api_path)
 
     def to_dict(self):
         """Returns a version of this spec that conforms to the API representation.
@@ -98,8 +99,28 @@ class PublishedClusterConfigurationSpec:
         :param new_versions_time_to_live: The new versions time to live.
         :type new_versions_time_to_live: str
         :return: A new spec.
-        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClusterConfigurationSpec`
+        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfigurationSpec`
         """
         return self.from_data(
             {**self._data, "versionsTimeToLive": new_versions_time_to_live}
+        )
+
+    def put(self):
+        """Commits these changes by updating the configuration in Tamr.
+
+        :return: The updated configuration.
+        :rtype: :class:`~tamr_unify_client.mastering.published_cluster.configuration.PublishedClustersConfiguration`
+        """
+        updated_json = (
+            self.client.put(self.api_path, json=self._data).successful().json()
+        )
+        return PublishedClustersConfiguration.from_json(
+            self.client, updated_json, self.api_path
+        )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}."
+            f"{self.__class__.__qualname__}("
+            f"dict={self._data})"
         )

--- a/tests/unit/test_published_clusters.py
+++ b/tests/unit/test_published_clusters.py
@@ -76,16 +76,17 @@ class PublishedClusterTest(TestCase):
     def test_update_published_clusters_configuration(self):
         def create_callback(request, snoop):
             snoop["payload"] = request.body
-            return 200, {}, json.dumps(self.update_info)
+            return 200, {}, json.dumps({"versionsTimeToLive": self.update_info})
 
-        url = "http://localhost/api/versioned/v1/projects/1/publishedClustersConfiguration"
+        path = "projects/1/publishedClustersConfiguration"
+        url = f"http://localhost:9100/api/versioned/v1/{path}"
         snoop_dict = {}
-        responses.add(responses.GET, url, self._config_json)
         responses.add_callback(
             responses.PUT, url, partial(create_callback, snoop=snoop_dict)
         )
-        clusters = PublishedClustersConfiguration(self.tamr, self._config_json)
-        new_cluster = clusters.spec().with_versions_time_to_live(self.update_info)
+
+        clusters = PublishedClustersConfiguration(self.tamr, self._config_json, path)
+        new_cluster = clusters.spec().with_versions_time_to_live(self.update_info).put()
         self.assertEqual(new_cluster._data, {"versionsTimeToLive": "PT100H"})
 
     @responses.activate


### PR DESCRIPTION

# ↪️ Pull Request

Fix #226, the previous PR didn't include put (and used cluster instead of clusters)

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
