### PR TITLE
Handle empty HTTP 204 responses for already-completed operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.10.0-dev
+  **BUG FIXES**
+  - [#293](https://github.com/Datatamer/tamr-client/issues/293) Better handling for HTTP 204 on already up-to-date operations
 
 ## 0.9.0
   **BREAKING CHANGES**

--- a/tamr_unify_client/dataset/profile.py
+++ b/tamr_unify_client/dataset/profile.py
@@ -77,8 +77,8 @@ class DatasetProfile(BaseResource):
         :returns: The refresh operation.
         :rtype: :class:`~tamr_unify_client.operation.Operation`
         """
-        op_json = self.client.post(self.api_path + ":refresh").successful().json()
-        op = Operation.from_json(self.client, op_json)
+        response = self.client.post(self.api_path + ":refresh").successful()
+        op = Operation.from_response(self.client, response)
         return op.apply_options(**options)
 
     def __repr__(self) -> str:

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -144,8 +144,8 @@ class Dataset(BaseResource):
         :returns: The refresh operation.
         :rtype: :class:`~tamr_unify_client.operation.Operation`
         """
-        op_json = self.client.post(self.api_path + ":refresh").successful().json()
-        op = Operation.from_json(self.client, op_json)
+        response = self.client.post(self.api_path + ":refresh").successful()
+        op = Operation.from_response(self.client, response)
         return op.apply_options(**options)
 
     def profile(self):
@@ -174,10 +174,8 @@ class Dataset(BaseResource):
         :return: The operation to create the profile.
         :rtype: :class:`~tamr_unify_client.operation.Operation`
         """
-        op_json = (
-            self.client.post(self.api_path + "/profile:refresh").successful().json()
-        )
-        op = Operation.from_json(self.client, op_json)
+        response = self.client.post(self.api_path + "/profile:refresh").successful()
+        op = Operation.from_response(self.client, response)
         return op.apply_options(**options)
 
     def records(self):

--- a/tamr_unify_client/mastering/estimated_pair_counts.py
+++ b/tamr_unify_client/mastering/estimated_pair_counts.py
@@ -63,8 +63,8 @@ class EstimatedPairCounts(BaseResource):
         :returns: The refresh operation.
         :rtype: :class:`~tamr_unify_client.operation.Operation`
         """
-        op_json = self.client.post(self.api_path + ":refresh").successful().json()
-        op = Operation.from_json(self.client, op_json)
+        response = self.client.post(self.api_path + ":refresh").successful()
+        op = Operation.from_response(self.client, response)
         return op.apply_options(**options)
 
     def __repr__(self) -> str:

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,0 +1,95 @@
+from urllib.parse import urljoin
+
+import pytest
+from requests import HTTPError
+import responses
+
+
+from tamr_unify_client.operation import Operation
+
+
+@pytest.fixture
+def client():
+    from tamr_unify_client import Client
+    from tamr_unify_client.auth import UsernamePasswordAuth
+
+    auth = UsernamePasswordAuth("username", "password")
+    tamr = Client(auth)
+    return tamr
+
+
+def full_url(client, endpoint):
+    return urljoin(client.origin + client.base_path, endpoint)
+
+
+op_1_json = {
+    "id": "1",
+    "type": "SPARK",
+    "description": "Profiling [dataset] attributes.",
+    "status": {
+        "state": "SUCCEEDED",
+        "startTime": "2019-08-28T18:51:06.856Z",
+        "endTime": "2019-08-28T18:53:08.204Z",
+        "message": "",
+    },
+    "created": {
+        "username": "admin",
+        "time": "2019-08-28T18:50:35.582Z",
+        "version": "17",
+    },
+    "lastModified": {
+        "username": "system",
+        "time": "2019-08-28T18:53:08.950Z",
+        "version": "40",
+    },
+    "relativeId": "operations/1",
+}
+
+
+def test_operation_from_json(client):
+    alias = "operations/123"
+    op1 = Operation.from_json(client, op_1_json, alias)
+    assert op1.api_path == alias
+    assert op1.relative_id == op_1_json["relativeId"]
+    assert op1.resource_id == "1"
+    assert op1.type == op_1_json["type"]
+    assert op1.description == op_1_json["description"]
+    assert op1.status == op_1_json["status"]
+    assert op1.state == "SUCCEEDED"
+    assert op1.succeeded
+
+
+@responses.activate
+def test_operation_from_response(client):
+    responses.add(responses.GET, full_url(client, "operations/1"), json=op_1_json)
+
+    op1 = Operation.from_response(client, client.get("operations/1").successful())
+
+    assert op1.resource_id == "1"
+    assert op1.succeeded
+
+
+@responses.activate
+def test_operation_from_response_noop(client):
+    responses.add(responses.GET, full_url(client, "operations/2"), status=204)
+    responses.add(responses.GET, full_url(client, "operations/-1"), status=404)
+
+    op2 = Operation.from_response(client, client.get("operations/2").successful())
+
+    assert op2.api_path is not None
+    assert op2.relative_id is not None
+    assert op2.resource_id is not None
+    assert op2.type == "NOOP"
+    assert op2.description is not None
+    assert op2.status is not None
+    assert op2.state == "SUCCEEDED"
+    assert op2.succeeded
+
+    op2a = op2.apply_options(asynchronous=True)
+    assert op2a.succeeded
+
+    op2w = op2a.wait()
+    assert op2w.succeeded
+
+    with pytest.raises(HTTPError):
+        op2w.poll()


### PR DESCRIPTION
# ↪️ Pull Request

Fix #293 Better handling for HTTP 204 on already up-to-date operations

Handle empty HTTP 204 responses for already-completed operations.

This creates a NOOP Operation to represent these cases.

## 💻 Examples

Before:
```
published_clusters = project.published_clusters()
try:
    published_clusters.refresh()
except json.JSONDecodeError:
    # In the event that the dataset we want to refresh is already up-to-date,
    # the API will return an HTTP 200 with an empty body, causing a JSONDecodeError.
    # We can safely ignore this error.
    pass
```
After:
```
published_clusters = project.published_clusters()
op = published_clusters.refresh()
assert op.successful
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
