### PR TITLE
Update docs "create project" example to include `with_external_id`

### DIFF
--- a/docs/user-guide/spec.rst
+++ b/docs/user-guide/spec.rst
@@ -35,6 +35,7 @@ For instance, to create a project::
         .with_type("DEDUP")
         .with_description("Mastering Project")
         .with_unified_dataset_name("Project_unified_dataset")
+        .with_external_id("tamrProject1")
     )
     project = tamr.projects.create(spec.to_dict())
 


### PR DESCRIPTION
# ↪️ Pull Request

Update the example project spec in the docs to include `with_external_id` to encourage best practices of using an external ID for referencing projects.

## 💻 Examples

N/A

## ✔️ PR Todo

- [n/a] Added/updated testing for this change
- [n/a] Included links to related issues/PRs
- [✔️] Update relevant [docs](https://github.com/Datatamer/unify-client-python/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/unify-client-python/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
