### PR TITLE
Flask proxy

### DIFF
--- a/examples/flask-proxy/app.py
+++ b/examples/flask-proxy/app.py
@@ -1,0 +1,23 @@
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+from flask_proxy import flask_proxy
+
+auth = UsernamePasswordAuth("username", "password")
+tamr = Client(auth, host="my_host")
+
+passthru = flask_proxy(tamr)
+app = Flask(__name__)
+
+
+@app.route("/api/versioned/v1/projects")
+def projects(*args, **kwargs):
+    print("projects endpoint was called!")
+    return passthru(*args, **kwargs)
+
+
+# all other endpoints, passthru without doing anything special
+app.route("/api/<path:path>", methods=["POST", "GET", "PUT", "DELETE"])(passthru)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/flask-proxy/flask_proxy.py
+++ b/examples/flask-proxy/flask_proxy.py
@@ -1,0 +1,72 @@
+import json
+from typing import Any, Callable
+
+from flask import request, Response
+import requests
+
+from tamr_unify_client import Client
+
+
+def proxy(tamr: Client):
+    """Proxy requests in Flask app to Tamr API.
+
+    Adapted from https://stackoverflow.com/a/36601467/1490091
+
+    Args:
+        tamr: Proxy requests via this Tamr Client
+
+    Returns:
+        Function `(*args, **kwargs) -> requests.Response`
+
+    Example:
+        Intercept a specific API endpoint to do some processing on it::
+
+            passthru = proxy(tamr)
+            app = Flask(__name__)
+
+            @app.route("/api/endpoint/to/intercept")
+            def some_route(*args, **kwargs):
+                # specially process this endpoint before passing it through to Tamr server
+                print('this endpoint was called!')
+                return passthru(*args, **kwargs)
+
+            # all other endpoints, passthru without doing anything special
+            app.route("/api/<path:path>", methods=["POST", "GET", "PUT", "DELETE"])(passthru)
+    """
+
+    def _proxy(*args: Any, **kwargs: Any) -> Response:
+        """Translates Flask's werkzeug.wrappers.Request to Tamr Client's
+        requests.Request and send that request to Tamr Client's host.
+
+        Returns:
+            Response from Tamr server.
+        """
+        r = requests.request(
+            method=request.method,
+            url=request.url.replace(request.host_url, tamr.origin + "/"),
+            headers={key: value for (key, value) in request.headers if key != "Host"},
+            data=request.get_data(),
+            cookies=request.cookies,
+            allow_redirects=False,
+        )
+
+        excluded_headers = [
+            "content-encoding",
+            "content-length",
+            "transfer-encoding",
+            "connection",
+        ]
+        headers = [
+            (name, value)
+            for (name, value) in r.raw.headers.items()
+            if name.lower() not in excluded_headers
+        ]
+
+        return Response(
+            r.iter_content(chunk_size=10 * 1024),
+            r.status_code,
+            headers,
+            content_type=r.headers.get("Content-Type"),
+        )
+
+    return _proxy

--- a/examples/flask-proxy/requirements.txt
+++ b/examples/flask-proxy/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+requests
+tamr-unify-client


### PR DESCRIPTION
# ↪️ Pull Request

Utility for using `tamr-client` to proxy requests in a Flask app.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
```python
tamr = Client(auth, host)

passthru = proxy(tamr)
app = Flask(__name__)

@app.route("/api/endpoint/to/intercept")
def some_route(*args, **kwargs):
    # specially process this endpoint before passing it through to Tamr server
    print('this endpoint was called!')
    return passthru(*args, **kwargs)

# all other endpoints, passthru without doing anything special
app.route("/api/<path:path>", methods=["POST", "GET", "PUT", "DELETE"])(passthru)
```
