### PR TITLE
Freeze doc requirements to their current poetry.lock versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # TODO(pcattori) Delete this file once RTD fully supports poetry
-recommonmark
-Sphinx
-sphinx_rtd_theme
-toml
+recommonmark==0.6.0
+Sphinx==2.1.0
+sphinx_rtd_theme==0.4.3
+toml==0.10.0
 .


### PR DESCRIPTION
# ↪️ Pull Request

Relates to #298 #299 

recommonmark's AutoStructify was producing a ToC correctly locally, but
not remotely on RTD. After some investigation, I found that RTD was
using different versions of doc dependencies (most notably Sphinx <2 on
RTD, whereas locally we are using 2.1.0). Hopefully, freezing the doc
dependencies to be consistent with local version should fix the ToC
rendering remotely.

## ✔️ PR Todo

- [n/a] Added/updated testing for this change
- [X] Included links to related issues/PRs
- [n/a] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [n/a] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
