### PR TITLE
CI/CD: fix Github Actions workflow syntax error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  name: Publish
+  Publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Programmatically 💻 interact with Tamr using Python 🐍
 
 [![Version](https://img.shields.io/pypi/v/tamr-unify-client.svg?style=flat-square)](https://pypi.org/project/tamr-unify-client/)
 [![Documentation Status](https://readthedocs.org/projects/tamr-client/badge/?version=stable&style=flat-square)](https://tamr-client.readthedocs.io/en/stable/?badge=stable)
-[![Build Status](https://img.shields.io/travis/Datatamer/tamr-client.svg?style=flat-square)](https://travis-ci.org/Datatamer/tamr-client)
+[![Build Status](https://img.shields.io/github/workflow/status/Datatamer/tamr-client/CI?&style=flat-square)](https://github.com/Datatamer/tamr-client/actions?query=workflow%3ACI)
 ![Supported Python Versions](https://img.shields.io/pypi/pyversions/tamr-unify-client.svg?style=flat-square)
 [![License](https://img.shields.io/pypi/l/tamr-unify-client.svg?style=flat-square)](LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/ambv/black)

--- a/README.md
+++ b/README.md
@@ -35,12 +35,8 @@ pip install tamr-unify-client
   - Train Tamr's machine learning models
   - Generate predictions from trained models
 - 🔒 Authenticate with Tamr
-- 📥 Fetch resources (e.g projects) by resource ID (e.g. `"1"`)
-- 📝 Read resource metadata
-- 🔁 Iterate over collections
-- ⚠️ Advanced
-  - Logging for API requests/responses
-  - Call custom/arbitrary API endpoints
+
+For more see the [official docs](https://tamr-client.readthedocs.io/en/stable/).
 
 ## Maintainers
 


### PR DESCRIPTION
# ↪️ Pull Request
Fix syntax error in `release.yml`: Job entry should be keyed by job name.

Also clean up README
- fix build badge (should reference Github Actions instead of Travis)