### PR TITLE
Add run project

### DIFF
--- a/tamr_unify_client/categorization/project.py
+++ b/tamr_unify_client/categorization/project.py
@@ -42,4 +42,28 @@ class CategorizationProject(Project):
         resource_json = self.client.get(alias).successful().json()
         return Taxonomy.from_json(self.client, resource_json, alias)
 
+    def run(self, refresh_unified_dataset=True, train_model=True, predict_model=True):
+        """Executes all steps of this project. Ending early if a step fails.
+
+        :param refresh_unified_dataset: Whether refresh should be called on the unified dataset
+        :type refresh_unified_dataset: bool
+        :param train_model: Whether train should be called on the pair matching model
+        :type train_model: bool
+        :param predict_model: Whether predict should be called on the pair matching model
+        :type predict_model: bool
+        :return: Responses from the operations that were run
+        :rtype: List :class:`~tamr_unify_client.operation.Operation`
+        """
+
+        # This list consists of a user defined boolean for whether a task should be done
+        # and the function to execute that task
+        possible_tasks = [
+            (refresh_unified_dataset, self.unified_dataset().refresh),
+            (train_model, self.model().train),
+            (predict_model, self.model().predict)
+        ]
+
+        wanted_tasks = [task for should_do, task in possible_tasks if should_do]
+        return self._run_subtasks(wanted_tasks)
+
     # super.__repr__ is sufficient

--- a/tamr_unify_client/project/resource.py
+++ b/tamr_unify_client/project/resource.py
@@ -178,6 +178,31 @@ class Project(BaseResource):
         """
         return ProjectSpec.of(self)
 
+    @staticmethod
+    def _run_subtasks(wanted_tasks):
+        """Executes a series of tasks and returns when any task fails or after all succeed
+
+        :param possible_tasks: Tasks to be execute in order
+        :type possible_tasks: List of functions
+        :return:
+        """
+        completed_operations = []
+        for task in wanted_tasks:
+            completed_operations.append(task())
+            if not completed_operations[-1].succeeded():
+                return completed_operations
+
+        return completed_operations
+
+    def run(self):
+        """Executes all steps of a project
+
+        :return: The operations submitted to execute the project
+        :rtype: :class: List `~tamr_unify_client.operation.Operation`
+        """
+        raise NotImplementedError("Run is not available in base project resource. "
+                                  "Convert to a specific project type in order to use run.")
+
     def __repr__(self):
         return (
             f"{self.__class__.__module__}."

--- a/tamr_unify_client/project/resource.py
+++ b/tamr_unify_client/project/resource.py
@@ -178,22 +178,6 @@ class Project(BaseResource):
         """
         return ProjectSpec.of(self)
 
-    @staticmethod
-    def _run_subtasks(wanted_tasks):
-        """Executes a series of tasks and returns when any task fails or after all succeed
-
-        :param possible_tasks: Tasks to be execute in order
-        :type possible_tasks: List of functions
-        :return:
-        """
-        completed_operations = []
-        for task in wanted_tasks:
-            completed_operations.append(task())
-            if not completed_operations[-1].succeeded():
-                return completed_operations
-
-        return completed_operations
-
     def run(self):
         """Executes all steps of a project
 

--- a/tamr_unify_client/project/resource.py
+++ b/tamr_unify_client/project/resource.py
@@ -93,6 +93,21 @@ class Project(BaseResource):
             )
         return MasteringProject(self.client, self._data, self.api_path)
 
+    def as_schema_mapping(self):
+        """Convert this project to a :class:`~tamr_unify_client.schema_mapping.project.SchemaMappingProject`
+
+        :return: This project.
+        :rtype: :class:`~tamr_unify_client.schema_mapping.project.SchemaMappingProject`
+        :raises TypeError: If the :attr:`~tamr_unify_client.project.resource.Project.type` of this project is not ``"SCHEMA_MAPPING_RECOMMENDATIONS"``
+        """
+        from tamr_unify_client.schema_mapping.project import SchemaMappingProject
+
+        if self.type != "SCHEMA_MAPPING_RECOMMENDATIONS":
+            raise TypeError(
+                f"Cannot convert project to schema mapping project. Project type: {self.type}"
+            )
+        return SchemaMappingProject(self.client, self._data, self.api_path)
+
     def add_input_dataset(self, dataset):
         """
         Associate a dataset with a project in Tamr.

--- a/tamr_unify_client/schema_mapping/project.py
+++ b/tamr_unify_client/schema_mapping/project.py
@@ -1,0 +1,5 @@
+from tamr_unify_client.project.resource import Project
+
+
+class SchemaMappingProject(Project):
+    """A Schema Mapping project in Tamr."""

--- a/tamr_unify_client/schema_mapping/project.py
+++ b/tamr_unify_client/schema_mapping/project.py
@@ -4,19 +4,19 @@ from tamr_unify_client.project.resource import Project
 class SchemaMappingProject(Project):
     """A Schema Mapping project in Tamr."""
 
-    def run(self, refresh_unified_dataset=True):
-        """Executes all steps of this project. Ending early if a step fails.
+    def run(self, *, refresh_unified_dataset=True):
+        """Executes all steps of this project.
 
         :param refresh_unified_dataset: Whether refresh should be called on the unified dataset
         :type refresh_unified_dataset: bool
         :rtype: List :class:`~tamr_unify_client.operation.Operation`
         """
 
-        # This list consists of a user defined boolean for whether a task should be done
-        # and the function to execute that task
-        possible_tasks = [
-            (refresh_unified_dataset, self.unified_dataset().refresh)
-        ]
-
-        wanted_tasks = [task for should_do, task in possible_tasks if should_do]
-        return self._run_subtasks(wanted_tasks)
+        completed_operations = []
+        if refresh_unified_dataset:
+            op = self.unified_dataset().refresh()
+            if not op.succeeded():
+                raise RuntimeError(f"Operation failed: {op}. Completed operations: {completed_operations}")
+            else:
+                completed_operations.append(op)
+        return completed_operations

--- a/tamr_unify_client/schema_mapping/project.py
+++ b/tamr_unify_client/schema_mapping/project.py
@@ -3,3 +3,20 @@ from tamr_unify_client.project.resource import Project
 
 class SchemaMappingProject(Project):
     """A Schema Mapping project in Tamr."""
+
+    def run(self, refresh_unified_dataset=True):
+        """Executes all steps of this project. Ending early if a step fails.
+
+        :param refresh_unified_dataset: Whether refresh should be called on the unified dataset
+        :type refresh_unified_dataset: bool
+        :rtype: List :class:`~tamr_unify_client.operation.Operation`
+        """
+
+        # This list consists of a user defined boolean for whether a task should be done
+        # and the function to execute that task
+        possible_tasks = [
+            (refresh_unified_dataset, self.unified_dataset().refresh)
+        ]
+
+        wanted_tasks = [task for should_do, task in possible_tasks if should_do]
+        return self._run_subtasks(wanted_tasks)


### PR DESCRIPTION
# ↪️ Pull Request
Adds a convince method "run" to each project type that runs all steps of a project in order
The run method also allows users to opt-out of individual steps
Adds "Schema Mapping" projects as a first-class citizen
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

my_project = tamr.projects.by_resource_id('1').as_mastering()
my_project.run(train_pairs_model=False)

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
