### PR TITLE
Include types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8"
 ]
+include = ["tamr_client/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8"
 ]
+packages = [
+    { include = "tamr_client" },
+    { include = "tamr_unify_client" },
+]
 include = ["tamr_client/py.typed"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
# ↪️ Pull Request

Previously, packaging would not include the `tamr_client` package AT ALL.
Now, we explicitly declare what packages should be included and we also include the `py.typed` empty file to mark this package as type checkable.

Users of `tamr_client` can now run type checking from their own codebase and get the expected type checks on code that interacts with `tamr_client`.

## 💻 Examples

```python
# blah.py

import tamr_client as tc

print(tc)
print(dir(tc))

attr = tc.Attribute(1)
```

```sh
(.venv) ❯ invoke typecheck
mypy scripts/example_script.py scripts/blah.py scripts/example_stream_dataset_by_name.py
scripts/blah.py:6: error: Too few arguments for "Attribute"
scripts/blah.py:6: error: Argument 1 to "Attribute" has incompatible type "int"; expected "URL"
Found 2 errors in 1 file (checked 3 source files)
```

## ✔️ PR Todo

- [N/A] Added/updated testing for this change
- [N/A] Included links to related issues/PRs
- [N/A] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [N/A] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
