### PR TITLE
Tc sessions

### DIFF
--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -8,7 +8,8 @@ import tamr_client.url as url
 
 import tamr_client.response as response
 from tamr_client.auth import UsernamePasswordAuth
-from tamr_client.session import session
+from tamr_client.session import Session
+import tamr_client.session as session
 
 # datasets
 from tamr_client.datasets.dataset import Dataset

--- a/tamr_client/attributes/attribute.py
+++ b/tamr_client/attributes/attribute.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field, replace
 from typing import Optional
 
 import tamr_client as tc
-from tamr_client.json_dict import JsonDict
+from tamr_client.types import JsonDict
 
 _RESERVED_NAMES = frozenset(
     [

--- a/tamr_client/attributes/attribute.py
+++ b/tamr_client/attributes/attribute.py
@@ -2,8 +2,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import Optional
 
-from requests import Session
-
 import tamr_client as tc
 from tamr_client.json_dict import JsonDict
 
@@ -67,7 +65,7 @@ class Attribute:
     description: Optional[str] = None
 
 
-def from_resource_id(session: Session, dataset: tc.Dataset, id: str) -> Attribute:
+def from_resource_id(session: tc.Session, dataset: tc.Dataset, id: str) -> Attribute:
     """Get attribute by resource ID
 
     Fetches attribute from Tamr server
@@ -85,7 +83,7 @@ def from_resource_id(session: Session, dataset: tc.Dataset, id: str) -> Attribut
     return _from_url(session, url)
 
 
-def _from_url(session: Session, url: tc.URL) -> Attribute:
+def _from_url(session: tc.Session, url: tc.URL) -> Attribute:
     """Get attribute by URL
 
     Fetches attribute from Tamr server
@@ -143,7 +141,7 @@ def to_json(attr: Attribute) -> JsonDict:
 
 
 def create(
-    session: Session,
+    session: tc.Session,
     dataset: tc.dataset.Dataset,
     *,
     name: str,
@@ -186,7 +184,7 @@ def create(
 
 
 def _create(
-    session: Session,
+    session: tc.Session,
     dataset: tc.dataset.Dataset,
     *,
     name: str,
@@ -217,7 +215,7 @@ def _create(
 
 
 def update(
-    session: Session, attribute: Attribute, *, description: Optional[str] = None
+    session: tc.Session, attribute: Attribute, *, description: Optional[str] = None
 ) -> Attribute:
     """Update an existing attribute
 
@@ -243,7 +241,7 @@ def update(
     return _from_json(attribute.url, data)
 
 
-def delete(session: Session, attribute: Attribute):
+def delete(session: tc.Session, attribute: Attribute):
     """Deletes an existing attribute
 
     Sends a deletion request to the Tamr server

--- a/tamr_client/attributes/attribute_type.py
+++ b/tamr_client/attributes/attribute_type.py
@@ -6,7 +6,7 @@ import logging
 from typing import ClassVar, Tuple, Union
 
 import tamr_client as tc
-from tamr_client.json_dict import JsonDict
+from tamr_client.types import JsonDict
 
 logger = logging.getLogger(__name__)
 

--- a/tamr_client/attributes/subattribute.py
+++ b/tamr_client/attributes/subattribute.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import tamr_client as tc
-from tamr_client.json_dict import JsonDict
+from tamr_client.types import JsonDict
 
 
 @dataclass(frozen=True)

--- a/tamr_client/datasets/dataset.py
+++ b/tamr_client/datasets/dataset.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass, replace
 from typing import Tuple
 
-from requests import Session
-
 import tamr_client as tc
 
 
@@ -12,7 +10,7 @@ class Dataset:
     key_attribute_names: Tuple[str, ...]
 
 
-def attributes(session: Session, dataset: Dataset) -> Tuple["tc.Attribute", ...]:
+def attributes(session: tc.Session, dataset: Dataset) -> Tuple["tc.Attribute", ...]:
     """Get attributes for this dataset
 
     Args:

--- a/tamr_client/json_dict.py
+++ b/tamr_client/json_dict.py
@@ -1,4 +1,0 @@
-# taken from https://github.com/python/typing/issues/182
-from typing import Any, Dict
-
-JsonDict = Dict[str, Any]

--- a/tamr_client/session.py
+++ b/tamr_client/session.py
@@ -1,7 +1,9 @@
 import requests
 
+Session = requests.Session
 
-def session(auth: requests.auth.HTTPBasicAuth, **kwargs) -> requests.Session:
+
+def from_auth(auth: requests.auth.HTTPBasicAuth, **kwargs) -> Session:
     """Create a new authenticated session
 
     Args:

--- a/tamr_client/types.py
+++ b/tamr_client/types.py
@@ -1,0 +1,4 @@
+from typing import Any, Dict
+
+# taken from https://github.com/python/typing/issues/182
+JsonDict = Dict[str, Any]

--- a/tests/attributes/test_attribute.py
+++ b/tests/attributes/test_attribute.py
@@ -63,8 +63,7 @@ def test_create():
 
 @responses.activate
 def test_update():
-    auth = tc.UsernamePasswordAuth("admin", "dt")
-    s = tc.session(auth)
+    s = utils.session()
 
     url = tc.URL(path="datasets/1/attributes/RowNum")
     attr_json = utils.load_json("attributes.json")[0]
@@ -81,8 +80,7 @@ def test_update():
 
 @responses.activate
 def test_delete():
-    auth = tc.UsernamePasswordAuth("admin", "dt")
-    s = tc.session(auth)
+    s = utils.session()
 
     url = tc.URL(path="datasets/1/attributes/RowNum")
     attr_json = utils.load_json("attributes.json")[0]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ def load_json(path: Union[str, Path]):
 
 def session():
     auth = tc.UsernamePasswordAuth("admin", "dt")
-    s = tc.session(auth)
+    s = tc.session.from_auth(auth)
     return s
 
 


### PR DESCRIPTION
# ↪️ Pull Request

`tc.Session` as a thin wrapper around `requests.Session` that ensures Auth.
`tc.session.from_auth` to create new sessions

Also, rename `tc.json_dict` to `tc.types`


## 💻 Examples

```python
import tamr_client as tc

s = tc.session.from_auth(tc.UsernamePasswordAuth('username', 'password'))

def blah(s: tc.Session) -> bool:
    ...
```

## ✔️ PR Todo

- [X] Added/updated testing for this change
- [N/A] Included links to related issues/PRs
- [N/A] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [N/A] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
