### PR TITLE
TUC: dataset.upsert_from_dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
       - functions: `tc.record.upsert`, `tc.record.delete`
     - `tc.dataframe` module
       - functions: `tc.dataframe.upsert`
+  - [#377](https://github.com/Datatamer/tamr-client/issues/377) dataset.upsert_from_dataframe() functionality added. Can now upsert records from a pandas DataFrame.
   **BUG FIXES**
   - Links from our docs to the `requests` docs were outdated. Links have been updated to point to the new `requests` docs URL.
   - [#323](https://github.com/Datatamer/tamr-client/issues/323) Documentation for setting `dtype=str` before calling `client.datasets.create_from_dataframe`

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+import pandas
 import simplejson as json
 
 from tamr_unify_client.attribute.collection import AttributeCollection
@@ -84,18 +85,22 @@ class Dataset(BaseResource):
             .json()
         )
 
-    def upsert_from_dataframe(self, df, primary_key_name, ignore_nan=True):
+    def upsert_from_dataframe(
+        self, df: pandas.DataFrame, primary_key_name: str, ignore_nan: bool = True
+    ) -> dict:
         """Upserts a record for each row of `df` with attributes for each column in `df`.
 
-        :param df: The data to upsert records from.
-        :type df: :class:`pandas.DataFrame`
-        :param primary_key_name: The name of the primary key of the dataset.  Must be a column of `df`.
-        :type primary_key_name: str
-        :param ignore_nan: Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
-        :type ignore_nan: bool
-        :returns: JSON response body from the server.
-        :rtype: dict
-        :raises KeyError: If `primary_key_name` is not a column in `df`.
+        Args:
+            df (pandas.DataFrame): The data to upsert records from.
+            primary_key_name (str): The name of the primary key of the dataset.  Must be a column of `df`.
+            ignore_nan (bool): Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
+
+        Returns:
+            dict: JSON response body from the server.
+
+        Raises:
+            KeyError: If `primary_key_name` is not a column in `df`.
+
         """
         if primary_key_name not in df.columns:
             raise KeyError(f"{primary_key_name} is not an attribute of the data")

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -86,7 +86,7 @@ class Dataset(BaseResource):
         )
 
     def upsert_from_dataframe(
-        self, df: pandas.DataFrame, primary_key_name: str, ignore_nan: bool = True
+        self, df: pandas.DataFrame, *, primary_key_name: str, ignore_nan: bool = True
     ) -> dict:
         """Upserts a record for each row of `df` with attributes for each column in `df`.
 

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-import pandas
+import pandas as pd
 import simplejson as json
 
 from tamr_unify_client.attribute.collection import AttributeCollection
@@ -86,17 +86,17 @@ class Dataset(BaseResource):
         )
 
     def upsert_from_dataframe(
-        self, df: pandas.DataFrame, *, primary_key_name: str, ignore_nan: bool = True
+        self, df: pd.DataFrame, *, primary_key_name: str, ignore_nan: bool = True
     ) -> dict:
         """Upserts a record for each row of `df` with attributes for each column in `df`.
 
         Args:
-            df (pandas.DataFrame): The data to upsert records from.
-            primary_key_name (str): The name of the primary key of the dataset.  Must be a column of `df`.
-            ignore_nan (bool): Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
+            df: The data to upsert records from.
+            primary_key_name: The name of the primary key of the dataset.  Must be a column of `df`.
+            ignore_nan: Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
 
         Returns:
-            dict: JSON response body from the server.
+            JSON response body from the server.
 
         Raises:
             KeyError: If `primary_key_name` is not a column in `df`.

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -84,6 +84,25 @@ class Dataset(BaseResource):
             .json()
         )
 
+    def upsert_from_dataframe(self, df, primary_key_name, ignore_nan=True):
+        """Upserts a record for each row of `df` with attributes for each column in `df`.
+
+        :param df: The data to upsert records from.
+        :type df: :class:`pandas.DataFrame`
+        :param primary_key_name: The name of the primary key of the dataset.  Must be a column of `df`.
+        :type primary_key_name: str
+        :param ignore_nan: Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
+        :type ignore_nan: bool
+        :returns: JSON response body from the server.
+        :rtype: dict
+        :raises KeyError: If `primary_key_name` is not a column in `df`.
+        """
+        if primary_key_name not in df.columns:
+            raise KeyError(f"{primary_key_name} is not an attribute of the data")
+
+        records = df.to_dict(orient="records")
+        return self.upsert_records(records, primary_key_name, ignore_nan=ignore_nan)
+
     def upsert_records(self, records, primary_key_name, **json_args):
         """Creates or updates the specified records.
 

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -116,7 +116,9 @@ class TestDatasetRecords(TestCase):
             responses.POST, records_url, partial(create_callback, snoop=snoop)
         )
 
-        response = dataset.upsert_from_dataframe(self._dataframe, "attribute1")
+        response = dataset.upsert_from_dataframe(
+            self._dataframe, primary_key_name="attribute1"
+        )
         self.assertEqual(response, self._response_json)
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
 

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -1,6 +1,7 @@
 from functools import partial
 from unittest import TestCase
 
+from pandas import DataFrame
 from requests.exceptions import HTTPError
 import responses
 import simplejson
@@ -100,6 +101,26 @@ class TestDatasetRecords(TestCase):
         self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
 
     @responses.activate
+    def test_upsert_from_dataframe(self):
+        def create_callback(request, snoop):
+            snoop["payload"] = list(request.body)
+            return 200, {}, simplejson.dumps(self._response_json)
+
+        responses.add(responses.GET, self._dataset_url, json={})
+        dataset = self.tamr.datasets.by_resource_id(self._dataset_id)
+
+        records_url = f"{self._dataset_url}:updateRecords"
+        updates = TestDatasetRecords.records_to_updates(self._records_json)
+        snoop = {}
+        responses.add_callback(
+            responses.POST, records_url, partial(create_callback, snoop=snoop)
+        )
+
+        response = dataset.upsert_from_dataframe(self._dataframe, "attribute1")
+        self.assertEqual(response, self._response_json)
+        self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(updates, False))
+
+    @responses.activate
     def test_delete(self):
         def create_callback(request, snoop):
             snoop["payload"] = list(request.body)
@@ -173,6 +194,7 @@ class TestDatasetRecords(TestCase):
     _dataset_url = f"http://localhost:9100/api/versioned/v1/datasets/{_dataset_id}"
 
     _records_json = [{"attribute1": 1}, {"attribute1": 2}]
+    _dataframe = DataFrame(_records_json, columns=["attribute1"])
     _nan_records_json = [{"attribute1": float("nan")}, {"attribute1": float("nan")}]
     _response_json = {
         "numCommandsProcessed": 2,


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds a convenience function to the dataset object to support upserting records from a pandas DataFrame.  This mirrors the function `datasets.create_from_dataframe` that allows a user to create a dataset from a DataFrame.  Like

Like `create_from_dataframe` the default behavior passes the JSON arg `ignore_nan=True` so that DataFrame nulls are handled gracefully.

Relates to #324 

## 💻 Examples

```python
import pandas as pd
from tamr_unify_client import Client

tamr_client = Client(auth, host)

df_jan = pd.read_csv("USA_Spend_Jan.csv", dtype='str')
primary_key_name = 'contract_transaction_unique_key'
dataset = tamr_client.datasets.create_from_dataframe(df_jan, primary_key_name, 'USA_Spend_Dataset')

df_feb = pd.read_csv("USA_Spend_Feb.csv", dtype='str')
dataset.upsert_from_dataframe(df_feb, primary_key_name)
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
