### PR TITLE
Move dataset.attributes -> attribute.from_dataset_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   - BETA: New attributes package!
     - `tc.attribute` module
       - `tc.Attribute` type
-      - functions: `from_resource_id`, `to_json`, `create`, `update`, `delete`
+      - functions: `from_resource_id`, `from_dataset_all`, `to_json`, `create`, `update`, `delete`
     - `tc.attribute_type` module
       - `tc.AttributeType` for type annotations
       - Primitive Types: `BOOLEAN`, `DOUBLE`, `INT`, `LONG`, `STRING`
@@ -18,7 +18,7 @@
   - BETA: New datasets package!
     - `tc.dataset` module
       - `tc.Dataset` type
-      - functions: `from_resource_id`, `attributes`
+      - functions: `from_resource_id`
   - BETA: New `tc.instance` module!
     - `tc.Instance` type
     - functions: `tc.instance.from_auth`

--- a/docs/beta/attributes/attribute.rst
+++ b/docs/beta/attributes/attribute.rst
@@ -4,6 +4,7 @@ Attribute
 .. autoclass:: tamr_client.Attribute
 
 .. autofunction:: tamr_client.attribute.from_resource_id
+.. autofunction:: tamr_client.attribute.from_dataset_all
 .. autofunction:: tamr_client.attribute.to_json
 .. autofunction:: tamr_client.attribute.create
 .. autofunction:: tamr_client.attribute.update

--- a/docs/beta/datasets/dataset.rst
+++ b/docs/beta/datasets/dataset.rst
@@ -4,7 +4,6 @@ Dataset
 .. autoclass:: tamr_client.Dataset
 
 .. autofunction:: tamr_client.dataset.from_resource_id
-.. autofunction:: tamr_client.dataset.attributes
 
 Exceptions
 ----------

--- a/tamr_client/attributes/attribute.py
+++ b/tamr_client/attributes/attribute.py
@@ -3,7 +3,7 @@ See https://docs.tamr.com/reference/attribute-types
 """
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
-from typing import Optional
+from typing import Optional, Tuple
 
 import tamr_client as tc
 from tamr_client.types import JsonDict
@@ -122,6 +122,31 @@ def _from_json(url: tc.URL, data: JsonDict) -> Attribute:
         type=tc.attribute_type.from_json(cp["type"]),
         _json=cp,
     )
+
+
+def from_dataset_all(session: tc.Session, dataset: tc.Dataset) -> Tuple[Attribute]:
+    """Get all attributes from a dataset
+
+    Args:
+        dataset: Dataset containing the desired attributes
+
+    Returns:
+        The attributes for the specified dataset
+
+    Raises:
+        requests.HTTPError: If an HTTP error is encountered.
+    """
+    attrs_url = replace(dataset.url, path=dataset.url.path + "/attributes")
+    r = session.get(str(attrs_url))
+    attrs_json = tc.response.successful(r).json()
+
+    attrs = []
+    for attr_json in attrs_json:
+        id = attr_json["name"]
+        attr_url = replace(attrs_url, path=attrs_url.path + f"/{id}")
+        attr = _from_json(attr_url, attr_json)
+        attrs.append(attr)
+    return tuple(attrs)
 
 
 def to_json(attr: Attribute) -> JsonDict:

--- a/tamr_client/datasets/dataset.py
+++ b/tamr_client/datasets/dataset.py
@@ -2,7 +2,7 @@
 See https://docs.tamr.com/reference/dataset-models
 """
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import tamr_client as tc
@@ -86,28 +86,3 @@ def _from_json(url: tc.URL, data: JsonDict) -> Dataset:
         description=cp.get("description"),
         key_attribute_names=tuple(cp["keyAttributeNames"]),
     )
-
-
-def attributes(session: tc.Session, dataset: Dataset) -> Tuple["tc.Attribute", ...]:
-    """Get attributes for this dataset
-
-    Args:
-        dataset: Dataset containing the desired attributes
-
-    Returns:
-        The attributes for the specified dataset
-
-    Raises:
-        requests.HTTPError: If an HTTP error is encountered.
-    """
-    attrs_url = replace(dataset.url, path=dataset.url.path + "/attributes")
-    r = session.get(str(attrs_url))
-    attrs_json = tc.response.successful(r).json()
-
-    attrs = []
-    for attr_json in attrs_json:
-        id = attr_json["name"]
-        attr_url = replace(attrs_url, path=attrs_url.path + f"/{id}")
-        attr = tc.attribute._from_json(attr_url, attr_json)
-        attrs.append(attr)
-    return tuple(attrs)

--- a/tests/attributes/test_attribute.py
+++ b/tests/attributes/test_attribute.py
@@ -124,6 +124,26 @@ def test_create_reserved_attribute_name():
 
 
 @responses.activate
+def test_from_dataset_all():
+    s = utils.session()
+    dataset = utils.dataset()
+
+    attrs_url = replace(dataset.url, path=dataset.url.path + "/attributes")
+    attrs_json = utils.load_json("attributes.json")
+    responses.add(responses.GET, str(attrs_url), json=attrs_json, status=204)
+
+    attrs = tc.attribute.from_dataset_all(s, dataset)
+
+    row_num = attrs[0]
+    assert row_num.name == "RowNum"
+    assert isinstance(row_num.type, tc.attribute_type.String)
+
+    geom = attrs[1]
+    assert geom.name == "geom"
+    assert isinstance(geom.type, tc.attribute_type.Record)
+
+
+@responses.activate
 def test_create_attribute_exists():
     s = utils.session()
     dataset = utils.dataset()

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1,5 +1,3 @@
-from dataclasses import replace
-
 import pytest
 import responses
 
@@ -32,23 +30,3 @@ def test_from_resource_id_dataset_not_found():
 
     with pytest.raises(tc.DatasetNotFound):
         tc.dataset.from_resource_id(s, instance, "1")
-
-
-@responses.activate
-def test_attributes():
-    s = utils.session()
-    dataset = utils.dataset()
-
-    attrs_url = replace(dataset.url, path=dataset.url.path + "/attributes")
-    attrs_json = utils.load_json("attributes.json")
-    responses.add(responses.GET, str(attrs_url), json=attrs_json, status=204)
-
-    attrs = tc.dataset.attributes(s, dataset)
-
-    row_num = attrs[0]
-    assert row_num.name == "RowNum"
-    assert isinstance(row_num.type, tc.attribute_type.String)
-
-    geom = attrs[1]
-    assert geom.name == "geom"
-    assert isinstance(geom.type, tc.attribute_type.Record)


### PR DESCRIPTION
Removes cyclic dependency between dataset and attribute
Adhere to `from_*` convention across codebase

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [N/A] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
