### PR TITLE
fix(typecheck): Non-zero exit code when typechecks fail

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 from invoke import task
 
@@ -24,15 +25,22 @@ def format(c, fix=False):
 
 @task
 def typecheck(c, warn=True):
+    exit_code = 0
     repo = Path(".")
 
     tc = repo / "tamr_client"
-    c.run(f"poetry run mypy --package {tc}", echo=True, pty=True, warn=warn)
+    result = c.run(f"poetry run mypy --package {tc}", echo=True, pty=True, warn=warn)
+    if not result.exited == 0:
+        exit_code = result.exited
 
     tc_tests = " ".join(
         str(x) for x in (repo / "tests" / "tamr_client").glob("**/*.py")
     )
     c.run(f"poetry run mypy {tc_tests}", echo=True, pty=True, warn=warn)
+    if not result.exited == 0:
+        exit_code = result.exited
+
+    sys.exit(exit_code)
 
 
 @task


### PR DESCRIPTION
# ↪️ Pull Request

Setting `warn=True` will cause invoke to always exit with 0 exit code,
so we inspect the result of the invoke run(s), and manually set the exit
code for the typecheck task accordingly.

## 💻 Examples

See this [false negative](https://github.com/Datatamer/tamr-client/pull/348/checks?check_run_id=540182921) before this change,
and this [true postive](https://github.com/Datatamer/tamr-client/runs/540263114?check_suite_focus=true) after this change.

## ✔️ PR Todo

- [N/A] Added/updated testing for this change
- [N/A] Included links to related issues/PRs
- [N/A] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [N/A] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
