### PR TITLE
Return the requests result of from_geo_features()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.12.0-dev
 
+  **BUG FIXES**
+  - `from_geo_features` now returns information on the operation.  
+
 ## 0.11.0
   **BETA**
 

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -253,6 +253,8 @@ class Dataset(BaseResource):
         :param features: geospatial features
         :param geo_attr: (optional) name of the Tamr attribute to use for the feature's geometry
         :type geo_attr: str
+        :returns: JSON response body from server.
+        :rtype: :py:class:`dict`
         """
         if hasattr(features, "__geo_interface__"):
             features = features.__geo_interface__

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -268,7 +268,7 @@ class Dataset(BaseResource):
         if geo_attr is None:
             geo_attr = self._geo_attr
 
-        self._update_records(
+        return self._update_records(
             self._features_to_updates(features, record_id, key_attrs, geo_attr)
         )
 


### PR DESCRIPTION
# ↪️ Pull Request

<!---
In the current implementation from_geo_features() does not return the result of the underlying call to `_update_records`. This PR fixes that.
-->

## 💻 Examples

Presently the following returns `NoneType`:
```
response = test_dataset.from_geo_features(sample_gdf)
type(response)
```

This change would update this to providing the message from the underlying `_update_records` and provide an output such as:
`{'numCommandsProcessed': 42, 'allCommandsSucceeded': True, 'validationErrors': []}`

## ✔️ PR Todo

- [N/A] Added/updated testing for this change
- [N/A] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
