### PR TITLE
Refactor Namespace for datasets module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 0.12.0-dev
+  **BETA**
+
+  Important: Do not use BETA features for production workflows.
+  
+  - [#367](https://github.com/Datatamer/tamr-client/issues/367) Support for projects:
+    - generic projects via `tc.project`
+    - Mastering projects via `tc.mastering.project`
 
   **BUG FIXES**
   - `from_geo_features` now returns information on the operation.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
   **BUG FIXES**
   - `from_geo_features` now returns information on the operation.  
+<<<<<<< HEAD
   
   **NEW FEATURES**
   - Added user documentation on [Geospatial functionalities with GeoPandas](https://github.com/Datatamer/tamr-client/blob/master/docs/user-guide/geo.md). Documented limitations in Geopandas and workarounds. 
+=======
+  - [#366](https://github.com/Datatamer/tamr-client/issues/366) Now able to connect to Tamr instance with implicit port
+>>>>>>> 5f7c6e2... Update CHANGELOG.
 
 ## 0.11.0
   **BETA**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   **BUG FIXES**
   - `from_geo_features` now returns information on the operation.  
+  
+  **NEW FEATURES**
+  - Added user documentation on [Geospatial functionalities with GeoPandas](https://github.com/Datatamer/tamr-client/blob/master/docs/user-guide/geo.md). Documented limitations in Geopandas and workarounds. 
 
 ## 0.11.0
   **BETA**

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Tamr
+   Copyright 2020 Tamr
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -9,5 +9,7 @@
   * [Auth](beta/auth)
   * [Dataset](beta/datasets)
   * [Instance](beta/instance)
+  * [Mastering](beta/mastering)
+  * [Project](beta/project)
   * [Response](beta/response)
   * [Session](beta/session)

--- a/docs/beta/mastering.md
+++ b/docs/beta/mastering.md
@@ -1,0 +1,3 @@
+# Mastering
+
+  * [Project](/beta/mastering/project)

--- a/docs/beta/mastering/project.rst
+++ b/docs/beta/mastering/project.rst
@@ -1,0 +1,4 @@
+Mastering Project
+=================
+
+.. autoclass:: tamr_client.mastering.Project

--- a/docs/beta/project.rst
+++ b/docs/beta/project.rst
@@ -1,0 +1,10 @@
+Project
+=======
+
+.. autofunction:: tamr_client.project.from_resource_id
+
+Exceptions
+----------
+
+.. autoclass:: tamr_client.project.NotFound
+  :no-inherited-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "Tamr - Python Client"
-copyright = "2019, Tamr"
+copyright = "2020, Tamr"
 author = "Tamr"
 
 

--- a/docs/user-guide/geo.md
+++ b/docs/user-guide/geo.md
@@ -38,6 +38,7 @@ geodataframe = geopandas.GeoDataFrame(...)
 dataset = client.dataset.by_name("my_dataset")
 dataset.from_geo_features(geodataframe)
 ```
+Note that there are currently some limitations to GeoPandas' implementation of the Geo Interface. See below for more details. 
 
 By default the features' geometries will be placed into the first dataset attribute with geometry
 type. You can override this by specifying the geometry attribute to use in the `geo_attr`
@@ -97,10 +98,13 @@ for feature in my_dataset.itergeofeatures():
 
 Alternatively, it is possible to load the full dataset as follows:
 ```python
+my_dataset = client.datasets.by_name("my_dataset")
 def geopandas_dataset(dataset):
     for feature in dataset.itergeofeatures():
         feature['properties']['primary_key'] = feature['id']
         yield feature
-df = gpd.GeoDataFrame.from_features(geo_dataset(test_dataset))
+df = gpd.GeoDataFrame.from_features(geo_dataset(my_dataset))
 df.set_index('primary_key')
+do_something(df)
+my_dataset.from_geo_features(df)
 ```

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -37,8 +37,8 @@ from tamr_client.session import Session
 import tamr_client.session as session
 
 # datasets
-from tamr_client.datasets.dataset import Dataset, DatasetNotFound
-import tamr_client.datasets.dataset as dataset
+from tamr_client.datasets import Dataset
+import tamr_client.datasets as dataset
 
 # attributes
 from tamr_client.attributes.subattribute import SubAttribute

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -64,3 +64,6 @@ import tamr_client.datasets.record as record
 # dataframe
 from tamr_client.datasets.dataframe import AmbiguousPrimaryKey
 import tamr_client.datasets.dataframe as dataframe
+
+import tamr_client.mastering as mastering
+import tamr_client.project as project

--- a/tamr_client/datasets/__init__.py
+++ b/tamr_client/datasets/__init__.py
@@ -1,2 +1,5 @@
 # This __init__.py file is necessary for `mypy --package`
 # See https://github.com/python/mypy/issues/5759
+
+from tamr_client.datasets.dataset import Dataset
+import tamr_client.datasets.dataset

--- a/tamr_client/datasets/dataset.py
+++ b/tamr_client/datasets/dataset.py
@@ -9,7 +9,7 @@ import tamr_client as tc
 from tamr_client.types import JsonDict
 
 
-class DatasetNotFound(Exception):
+class NotFound(Exception):
     """Raised when referencing (e.g. updating or deleting) a dataset
     that does not exist on the server.
     """

--- a/tamr_client/instance.py
+++ b/tamr_client/instance.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class Instance:
     protocol: str = "http"
     host: str = "localhost"
-    port: int = 9100
+    port: Optional[int] = 9100
 
 
 def origin(instance: Instance) -> str:
@@ -13,4 +14,7 @@ def origin(instance: Instance) -> str:
 
     For additional information, see `MDN web docs <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>`_ .
     """
-    return f"{instance.protocol}://{instance.host}:{instance.port}"
+    if instance.port is None:
+        return f"{instance.protocol}://{instance.host}"
+    else:
+        return f"{instance.protocol}://{instance.host}:{instance.port}"

--- a/tamr_client/instance.py
+++ b/tamr_client/instance.py
@@ -6,7 +6,7 @@ from typing import Optional
 class Instance:
     protocol: str = "http"
     host: str = "localhost"
-    port: Optional[int] = 9100
+    port: Optional[int] = None
 
 
 def origin(instance: Instance) -> str:

--- a/tamr_client/mastering/__init__.py
+++ b/tamr_client/mastering/__init__.py
@@ -1,0 +1,8 @@
+# flake8: noqa
+"""
+Tamr - Mastering
+See https://docs.tamr.com/docs/overall-workflow-mastering
+"""
+
+from tamr_client.mastering.project import Project
+import tamr_client.mastering.project

--- a/tamr_client/mastering/project.py
+++ b/tamr_client/mastering/project.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import tamr_client as tc
+from tamr_client.types import JsonDict
+
+
+@dataclass(frozen=True)
+class Project:
+    """A Tamr Mastering project
+
+    See https://docs.tamr.com/reference/the-project-object
+
+    Args:
+        url
+        name
+        description
+    """
+
+    url: tc.URL
+    name: str
+    description: Optional[str] = None
+
+
+def _from_json(url: tc.URL, data: JsonDict) -> Project:
+    """Make mastering project from JSON data (deserialize)
+
+    Args:
+        url: Project URL
+        data: Project JSON data from Tamr server
+    """
+    return tc.mastering.Project(
+        url, name=data["name"], description=data.get("description")
+    )

--- a/tamr_client/project.py
+++ b/tamr_client/project.py
@@ -1,0 +1,65 @@
+from typing import Union
+
+import tamr_client as tc
+from tamr_client.types import JsonDict
+
+Project = Union[tc.mastering.Project]
+
+
+class NotFound(Exception):
+    """Raised when referencing (e.g. updating or deleting) a project
+    that does not exist on the server."""
+
+    pass
+
+
+def from_resource_id(session: tc.Session, instance: tc.Instance, id: str) -> Project:
+    """Get project by resource ID
+
+    Fetches project from Tamr server
+
+    Args:
+        instance: Tamr instance containing this dataset
+        id: Project ID
+
+    Raises:
+        NotFound: If no project could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    url = tc.URL(instance=instance, path=f"projects/{id}")
+    return _from_url(session, url)
+
+
+def _from_url(session: tc.Session, url: tc.URL) -> Project:
+    """Get project by URL
+
+    Fetches project from Tamr server
+
+    Args:
+        url: Project URL
+
+    Raises:
+        NotFound: If no project could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    data = tc.response.successful(r).json()
+    return _from_json(url, data)
+
+
+def _from_json(url: tc.URL, data: JsonDict) -> Project:
+    """Make project from JSON data (deserialize)
+
+    Args:
+        url: Project URL
+        data: Project JSON data from Tamr server
+    """
+    proj_type = data["type"]
+    if proj_type == "DEDUP":
+        return tc.mastering.project._from_json(url, data)
+    else:
+        raise ValueError(f"Unrecognized project type '{proj_type}' in {repr(data)}")

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -43,7 +43,7 @@ class Client:
         auth: requests.auth.AuthBase,
         host: str = "localhost",
         protocol: str = "http",
-        port: int = 9100,
+        port: Optional[int] = 9100,
         base_path: str = "/api/versioned/v1/",
         session: Optional[requests.Session] = None,
     ):
@@ -70,7 +70,10 @@ class Client:
 
         For additional information, see `MDN web docs <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>`_ .
         """
-        return f"{self.protocol}://{self.host}:{self.port}"
+        if self.port is None:
+            return f"{self.protocol}://{self.host}"
+        else:
+            return f"{self.protocol}://{self.host}:{self.port}"
 
     def request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
         """Sends a request to Tamr.

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -36,6 +36,7 @@ class Client:
         >>> auth = UsernamePasswordAuth('my username', 'my password')
         >>> tamr_local = Client(auth) # on http://localhost:9100
         >>> tamr_remote = Client(auth, protocol='https', host='10.0.10.0') # on https://10.0.10.0:9100
+        >>> tamr_remote = Client(auth, protocol='https', host='10.0.10.0', port=None) # on https://10.0.10.0
     """
 
     def __init__(

--- a/tests/tamr_client/data/mastering_project.json
+++ b/tests/tamr_client/data/mastering_project.json
@@ -1,0 +1,19 @@
+{
+    "id": "unify://unified-data/v1/projects/1",
+    "name": "proj",
+    "description": "Mastering Project",
+    "type": "DEDUP",
+    "unifiedDatasetName": "proj_unified_dataset",
+    "created": {
+        "username": "admin",
+        "time": "2020-04-03T14:14:18.752Z",
+        "version": "18"
+    },
+    "lastModified": {
+        "username": "admin",
+        "time": "2020-04-03T14:14:20.115Z",
+        "version": "19"
+    },
+    "relativeId": "projects/1",
+    "externalId": "58bdbe72-3c08-427d-97bd-45b16d92c79c"
+}

--- a/tests/tamr_client/test_instance.py
+++ b/tests/tamr_client/test_instance.py
@@ -1,0 +1,21 @@
+import tamr_client as tc
+
+
+def test_instance_default():
+    instance = tc.Instance()
+    assert tc.instance.origin(instance) == "http://localhost"
+
+
+def test_client_set_protocol():
+    instance = tc.Instance(protocol="https")
+    assert tc.instance.origin(instance) == "https://localhost"
+
+
+def test_client_set_host():
+    instance = tc.Instance(host="123.123.123.123")
+    assert tc.instance.origin(instance) == "http://123.123.123.123"
+
+
+def test_client_set_port():
+    instance = tc.Instance(port=9100)
+    assert tc.instance.origin(instance) == "http://localhost:9100"

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -1,0 +1,32 @@
+import pytest
+import responses
+
+import tamr_client as tc
+import tests.tamr_client.utils as utils
+
+
+@responses.activate
+def test_from_resource_id_mastering():
+    s = utils.session()
+    instance = utils.instance()
+
+    project_json = utils.load_json("mastering_project.json")
+    url = tc.URL(path="projects/1")
+    responses.add(responses.GET, str(url), json=project_json)
+
+    project = tc.project.from_resource_id(s, instance, "1")
+    assert isinstance(project, tc.mastering.Project)
+    assert project.name == "proj"
+    assert project.description == "Mastering Project"
+
+
+@responses.activate
+def test_from_resource_id_not_found():
+    s = utils.session()
+    instance = utils.instance()
+
+    url = tc.URL(path="projects/1")
+    responses.add(responses.GET, str(url), status=404)
+
+    with pytest.raises(tc.project.NotFound):
+        tc.project.from_resource_id(s, instance, "1")

--- a/tests/unit/test_client_origin.py
+++ b/tests/unit/test_client_origin.py
@@ -1,0 +1,37 @@
+from tamr_unify_client import Client
+from tamr_unify_client.auth import UsernamePasswordAuth
+
+
+def test_client_default():
+    auth = UsernamePasswordAuth("username", "password")
+    client = Client(auth)
+
+    assert client.origin == "http://localhost:9100"
+
+
+def test_client_set_protocol():
+    auth = UsernamePasswordAuth("username", "password")
+    client = Client(auth, protocol="https")
+
+    assert client.origin == "https://localhost:9100"
+
+
+def test_client_set_host():
+    auth = UsernamePasswordAuth("username", "password")
+    client = Client(auth, host="123.123.123.123")
+
+    assert client.origin == "http://123.123.123.123:9100"
+
+
+def test_client_set_port():
+    auth = UsernamePasswordAuth("username", "password")
+    client = Client(auth, port=80)
+
+    assert client.origin == "http://localhost:80"
+
+
+def test_client_set_port_none():
+    auth = UsernamePasswordAuth("username", "password")
+    client = Client(auth, port=None)
+
+    assert client.origin == "http://localhost"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
Refactored namespace for datasets module in BETA. `Dataset` pulled up to `tc.datasets` level in `tamr_client/datasets/__init__.py` and then further in `tamr_client/__init__.py`. Furthermore, `DatasetNotFound` exception is now just `NotFound` and only pulled up to `datasets` level, and will read `tc.dataset.NotFound` when raised.
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [] Added/updated testing for this change
- [] Included links to related issues/PRs
- [] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
