### PR TITLE
TC: Migrate imports to new style

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -1,6 +1,7 @@
 # Contributor guide
 
   * [Bug Reports and Feature Requests](contributor-guide/bugs-and-features)
+  * [Style Guide](contributor-guide/style-guide)
   * [Code Migrations](contributor-guide/migration)
   * [Configure your Text Editor](contributor-guide/config-text-editor)
   * [Install](contributor-guide/install)

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -1,11 +1,11 @@
 # Contributor guide
 
   * [Bug Reports and Feature Requests](contributor-guide/bugs-and-features)
-  * [Style Guide](contributor-guide/style-guide)
   * [Code Migrations](contributor-guide/migration)
   * [Configure your Text Editor](contributor-guide/config-text-editor)
   * [Install](contributor-guide/install)
   * [Navigating Inheritance](contributor-guide/navigating-inheritance)
   * [Pull Requests](contributor-guide/pull-request)
   * [Run and Build](contributor-guide/run-and-build)
+  * [Style Guide](contributor-guide/style-guide)
   * [Toolchain](contributor-guide/toolchain)

--- a/docs/contributor-guide/style-guide.md
+++ b/docs/contributor-guide/style-guide.md
@@ -13,7 +13,7 @@ Code should generally conform to the [PEP8 style guidelines](https://www.python.
 All functions and class definitions should use [Google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) and be annotated with [type hints](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#type-annotations).
 
 ### Internal Imports
-When importing from within <code>tamr-client</code>:
+When importing from within `tamr-client`:
 * Use import statements for modules, classes, and exceptions
-* Never import functions directly. Instead import the containing module and use <code>module.function</code>
-* Use <code>from foo import bar</code> instead of <code>import foo.bar as bar</code>
+* Never import functions directly. Instead import the containing module and use `module.function`
+* Use `from foo import bar` instead of `import foo.bar as bar`

--- a/docs/contributor-guide/style-guide.md
+++ b/docs/contributor-guide/style-guide.md
@@ -1,0 +1,19 @@
+# Style Guide
+
+### Formatting
+Code should generally conform to the [PEP8 style guidelines](https://www.python.org/dev/peps/pep-0008/). 
+  * [Flake8](https://flake8.pycqa.org/en/latest/) is a linter to help check that code is aligned with these formatting requirements
+  * [Black](https://black.readthedocs.io/en/stable/) is a formatter that can be used to automatically reformat code to resolve many (but not all) formatting issues
+  * For details on using these tools [see here](run-and-build)
+
+### Structure
+* Classes with methods should be avoided in favor of simple [dataclasses](https://docs.python.org/3/library/dataclasses.html) and functions
+
+### Google-style docstrings
+All functions and class definitions should use [Google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) and be annotated with [type hints](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#type-annotations).
+
+### Internal Imports
+When importing from within <code>tamr-client</code>:
+* Use import statements for modules, classes, and exceptions
+* Never import functions directly. Instead import the containing module and use <code>module.function</code>
+* Use <code>from foo import bar</code> instead of <code>import foo.bar as bar</code>

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -19,26 +19,26 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 ##################
 
 # utilities
-import tamr_client.response as response
+from tamr_client import response
 
 # instance
 from tamr_client.instance import Instance
-import tamr_client.instance as instance
+from tamr_client import instance
 
 # url
 from tamr_client.url import URL
-import tamr_client.url as url
+from tamr_client import url
 
 # auth
 from tamr_client.auth import UsernamePasswordAuth
 
 # session
 from tamr_client.session import Session
-import tamr_client.session as session
+from tamr_client import session
 
 # datasets
 from tamr_client.dataset import Dataset, DatasetNotFound
-import tamr_client.dataset as dataset
+from tamr_client import dataset
 
 # records
 from tamr_client.dataset.record import PrimaryKeyNotFound
@@ -50,10 +50,10 @@ from tamr_client.dataset import dataframe
 
 # attributes
 from tamr_client.attributes.subattribute import SubAttribute
-import tamr_client.attributes.subattribute as subattribute
+from tamr_client.attributes import subattribute
 
 from tamr_client.attributes.attribute_type import AttributeType
-import tamr_client.attributes.attribute_type as attribute_type
+from tamr_client.attributes import attribute_type
 
 import tamr_client.attributes.type_alias
 
@@ -63,7 +63,7 @@ from tamr_client.attributes.attribute import (
     AttributeExists,
     AttributeNotFound,
 )
-import tamr_client.attributes.attribute as attribute
+from tamr_client.attributes import attribute
 
-import tamr_client.mastering as mastering
-import tamr_client.project as project
+from tamr_client import mastering
+from tamr_client import project

--- a/tamr_client/attributes/attribute.py
+++ b/tamr_client/attributes/attribute.py
@@ -5,11 +5,10 @@ from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import Optional, Tuple
 
-import tamr_client.attributes.attribute_type as attribute_type
+from tamr_client import response
+from tamr_client.attributes import attribute_type, type_alias
 from tamr_client.attributes.attribute_type import AttributeType
-import tamr_client.attributes.type_alias as type_alias
 from tamr_client.dataset.dataset import Dataset
-import tamr_client.response as response
 from tamr_client.session import Session
 from tamr_client.types import JsonDict
 from tamr_client.url import URL

--- a/tamr_client/dataset/dataset.py
+++ b/tamr_client/dataset/dataset.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from tamr_client import response
 from tamr_client.instance import Instance
-import tamr_client.response as response
 from tamr_client.session import Session
 from tamr_client.types import JsonDict
 from tamr_client.url import URL

--- a/tamr_client/dataset/record.py
+++ b/tamr_client/dataset/record.py
@@ -7,8 +7,8 @@ underlying _update function can be used directly."
 import json
 from typing import cast, Dict, IO, Iterable, Optional
 
+from tamr_client import response
 from tamr_client.dataset.dataset import Dataset
-import tamr_client.response as response
 from tamr_client.session import Session
 from tamr_client.types import JsonDict
 

--- a/tamr_client/project.py
+++ b/tamr_client/project.py
@@ -1,9 +1,9 @@
 from typing import Union
 
+from tamr_client import response
 from tamr_client.instance import Instance
-import tamr_client.mastering.project as mastering_project
+from tamr_client.mastering import project as mastering_project
 from tamr_client.mastering.project import Project as MasteringProject
-import tamr_client.response as response
 from tamr_client.session import Session
 from tamr_client.types import JsonDict
 from tamr_client.url import URL

--- a/tamr_client/url.py
+++ b/tamr_client/url.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-import tamr_client.instance as instance
+from tamr_client import instance
 from tamr_client.instance import Instance
 
 

--- a/tests/tamr_client/attributes/test_attribute.py
+++ b/tests/tamr_client/attributes/test_attribute.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 def test_from_json():

--- a/tests/tamr_client/attributes/test_attribute_type.py
+++ b/tests/tamr_client/attributes/test_attribute_type.py
@@ -1,5 +1,5 @@
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 def test_from_json():

--- a/tests/tamr_client/datasets/test_dataframe.py
+++ b/tests/tamr_client/datasets/test_dataframe.py
@@ -6,7 +6,7 @@ import pytest
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 @responses.activate

--- a/tests/tamr_client/datasets/test_dataset.py
+++ b/tests/tamr_client/datasets/test_dataset.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 @responses.activate

--- a/tests/tamr_client/datasets/test_record.py
+++ b/tests/tamr_client/datasets/test_record.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 @responses.activate

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 @responses.activate

--- a/tests/tamr_client/test_response.py
+++ b/tests/tamr_client/test_response.py
@@ -3,7 +3,7 @@ import json
 import responses
 
 import tamr_client as tc
-import tests.tamr_client.utils as utils
+from tests.tamr_client import utils
 
 
 @responses.activate


### PR DESCRIPTION
# ↪️ Pull Request

Migration of imports to conform to new style.  This solves issues with circular imports in Python 3.6.
 
Old: `import foo.bar as bar`
New: `from foo import bar`

See:
- "Circular imports involving absolute imports with binding a submodule to a name are now supported": https://docs.python.org/3/whatsnew/3.7.html
- https://stackoverflow.com/a/24968941/1490091


## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
