### PR TITLE
Add section for maintainers in contributor docs

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -26,3 +26,18 @@ Submit feature requests as [Github issues](https://github.com/Datatamer/tamr-cli
 * [Configure your text editor](contributor-guide/text-editor)
 * [Read the style guide](contributor-guide/style-guide)
 * [Submit a pull request](contributor-guide/pull-request)
+
+
+## Maintainers
+
+Maintainer responsabilities:
+- Triage issues
+- Review + merge pull requests
+- Discuss RFCs
+- Publish new releases
+
+Current maintainers:
+- [pcattori](https://github.com/pcattori)
+
+Want to become a maintainer?
+Open a pull request that adds your name to the list of current maintainers!


### PR DESCRIPTION
# ↪️ Pull Request

Resolves #80 

Also, describe how others can become maintainers

## ✔️ PR Todo

- [n/a] Added/updated testing for this change
- [X] Included links to related issues/PRs
- [X] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
