### PR TITLE
Hide beta module from users

### DIFF
--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -1,9 +1,9 @@
 # BETA check
 ############
 
-import tamr_client.beta as beta
+from tamr_client import _beta
 
-beta._check()
+_beta.check()
 
 # Logging
 #########
@@ -13,10 +13,13 @@ import logging
 # https://docs.python-guide.org/writing/logging/#logging-in-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
+# types
+#######
+
 from tamr_client._types import Attribute, AttributeType, SubAttribute, URL
 
-# Import shortcuts
-##################
+# functions
+###########
 
 # utilities
 from tamr_client import response

--- a/tamr_client/_beta.py
+++ b/tamr_client/_beta.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 
-def _check():
+def check():
     beta_flag = "TAMR_CLIENT_BETA"
     beta_enabled = "1"
     beta = os.environ.get(beta_flag)


### PR DESCRIPTION
# ↪️ Pull Request

Previously, the `beta._check` indicated that the `_check` function is not part of the intended interface. But in reality, the entire `beta` module is not an intended interface. So we rename the module to `_beta`. Now that the module is `_` prefixed, there is no need to do the same for the function: `_beta.check`

Also fix `import x.y as y` to be `from x import y`, according to the style guide.

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
