### PR TITLE
Ignore F401 flake8 error explicitly

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,11 +7,9 @@ max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,I,W,T4,B9
 exclude = build,.venv,*.egg-info
-
 per-file-ignores =
     tamr_client/__init__.py:E402,F401,I100,I202
-    tamr_client/_types/__init__.py:F401
-    tamr_client/attribute/__init__.py:F401
+    tamr_client/*/__init__.py:F401
 
 # flake8-import-order plugin
 import-order-style = google

--- a/tamr_client/dataset/__init__.py
+++ b/tamr_client/dataset/__init__.py
@@ -1,5 +1,4 @@
-# flake8: noqa
+from tamr_client.dataset import dataframe, record, unified
 from tamr_client.dataset.dataset import AnyDataset, Dataset
 from tamr_client.dataset.dataset import from_resource_id
 from tamr_client.dataset.dataset import NotFound
-from tamr_client.dataset import dataframe, record, unified

--- a/tamr_client/mastering/__init__.py
+++ b/tamr_client/mastering/__init__.py
@@ -1,7 +1,6 @@
-# flake8: noqa
 """
 Tamr - Mastering
 See https://docs.tamr.com/docs/overall-workflow-mastering
 """
-from tamr_client.mastering.project import Project
 import tamr_client.mastering.project
+from tamr_client.mastering.project import Project


### PR DESCRIPTION
# ↪️ Pull Request

Resolves #402 

__init__.py files are used to control the interface exposed to the user
and do not contain any logic.

For now tamr_client/__init__.py also ignores other errors, but in the
future this file should also only ignore F401 errors.

## ✔️ PR Todo

- [n/a] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [n/a] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
