### PR TITLE
Fix errors related to TUC pandas usage

### DIFF
--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
+import os
+from typing import TYPE_CHECKING
 
-import pandas as pd
 import simplejson as json
 
 from tamr_unify_client.attribute.collection import AttributeCollection
@@ -10,6 +11,10 @@ from tamr_unify_client.dataset.status import DatasetStatus
 from tamr_unify_client.dataset.uri import DatasetURI
 from tamr_unify_client.dataset.usage import DatasetUsage
 from tamr_unify_client.operation import Operation
+
+BUILDING_DOCS = os.environ.get("TAMR_CLIENT_DOCS") == "1"
+if TYPE_CHECKING or BUILDING_DOCS:
+    import pandas as pd
 
 
 class Dataset(BaseResource):
@@ -86,7 +91,7 @@ class Dataset(BaseResource):
         )
 
     def upsert_from_dataframe(
-        self, df: pd.DataFrame, *, primary_key_name: str, ignore_nan: bool = True
+        self, df: "pd.DataFrame", *, primary_key_name: str, ignore_nan: bool = True
     ) -> dict:
         """Upserts a record for each row of `df` with attributes for each column in `df`.
 


### PR DESCRIPTION
pandas is now a dev dependency, bu tuc/dataset/resource.py imports
pandas. It does so merely for type annotations, so the same treatment is
applied as for tc/dataset/dataframe.py .

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
