### PR TITLE
Allow creation of an Operation from job resource ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
   Important: Do not use BETA features for production workflows.
   - Added function to get operation from resource ID
   
+  **NEW FEATURES**
+  - [#383](https://github.com/Datatamer/tamr-client/issues/383) Now able to create an Operation from Job resource id
+  
 ## 0.12.0
   **BETA**
   Important: Do not use BETA features for production workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.13.0-dev
-
+  **BETA**
+  Important: Do not use BETA features for production workflows.
+  - Added function to get operation from resource ID
+  
 ## 0.12.0
   **BETA**
   Important: Do not use BETA features for production workflows.

--- a/docs/beta/operation.rst
+++ b/docs/beta/operation.rst
@@ -6,3 +6,4 @@ Operation
 .. autofunction:: tamr_client.operation.poll
 .. autofunction:: tamr_client.operation.wait
 .. autofunction:: tamr_client.operation.succeeded
+.. autofunction:: tamr_client.operation.from_resource_id

--- a/tamr_client/operation.py
+++ b/tamr_client/operation.py
@@ -77,7 +77,7 @@ def from_resource_id(
         resource_id: The ID of the operation
     """
     url = URL(instance=instance, path=f"operations/{resource_id}")
-    r = session.get(str(url), headers={"Accept": "application/json"})
+    r = session.get(str(url))
     return _from_response(instance, r)
 
 

--- a/tamr_client/operation.py
+++ b/tamr_client/operation.py
@@ -68,6 +68,19 @@ def succeeded(operation: Operation) -> bool:
     return operation.status is not None and operation.status["state"] == "SUCCEEDED"
 
 
+def from_resource_id(
+    session: Session, instance: Instance, resource_id: str
+) -> Operation:
+    """Get operation by ID
+
+    Args:
+        resource_id: The ID of the operation
+    """
+    url = URL(instance=instance, path=f"operations/{resource_id}")
+    r = session.get(str(url), headers={"Accept": "application/json"})
+    return _from_response(instance, r)
+
+
 def _from_response(instance: Instance, response: requests.Response) -> Operation:
     """
     Handle idiosyncrasies in constructing Operations from Tamr responses.

--- a/tamr_unify_client/operation.py
+++ b/tamr_unify_client/operation.py
@@ -30,7 +30,7 @@ class Operation(BaseResource):
         :rtype: :class:`~tamr_unify_client.operation.Operation`
         """
         url = f"operations/{resource_id}"
-        response = client.get(url, headers={"Accept": "application/json"}).successful()
+        response = client.get(url).successful()
         return Operation.from_response(client, response)
 
     @classmethod

--- a/tamr_unify_client/operation.py
+++ b/tamr_unify_client/operation.py
@@ -19,6 +19,21 @@ class Operation(BaseResource):
         return super().from_data(client, resource_json, api_path)
 
     @classmethod
+    def from_resource_id(cls, client, resource_id):
+        """Get an operation by resource ID.
+
+        :param client: Delegate underlying API calls to this client.
+        :type client: :class:`~tamr_unify_client.Client`
+        :param resource_id: The ID of the operation
+        :type resource_id: str
+        :returns: The specified operation
+        :rtype: :class:`~tamr_unify_client.operation.Operation`
+        """
+        url = f"operations/{resource_id}"
+        response = client.get(url, headers={"Accept": "application/json"}).successful()
+        return Operation.from_response(client, response)
+
+    @classmethod
     def from_response(cls, client, response):
         """
         Handle idiosyncrasies in constructing Operations from Tamr responses.

--- a/tests/tamr_client/test_operation.py
+++ b/tests/tamr_client/test_operation.py
@@ -78,6 +78,24 @@ def test_operation_from_response_noop():
 
 
 @responses.activate
+def test_from_resource_id():
+    s = utils.session()
+    instance = utils.instance()
+    url = tc.URL(path="operations/1")
+
+    operation_json = utils.load_json("operation_succeeded.json")
+    responses.add(responses.GET, str(url), json=operation_json)
+
+    resource_id = "1"
+    op = tc.operation.from_resource_id(s, instance, resource_id)
+    assert op.url == url
+    assert op.type == operation_json["type"]
+    assert op.description == operation_json["description"]
+    assert op.status == operation_json["status"]
+    assert tc.operation.succeeded(op)
+
+
+@responses.activate
 def test_operation_poll():
     s = utils.session()
     url = tc.URL(path="operations/1")

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -60,6 +60,16 @@ def test_operation_from_json(client):
 
 
 @responses.activate
+def test_operation_from_resource_id(client):
+    responses.add(responses.GET, full_url(client, "operations/1"), json=op_1_json)
+
+    op1 = Operation.from_resource_id(client, "1")
+
+    assert op1.resource_id == "1"
+    assert op1.succeeded
+
+
+@responses.activate
 def test_operation_from_response(client):
     responses.add(responses.GET, full_url(client, "operations/1"), json=op_1_json)
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR adds functionality to both TC and TUC allowing a user to fetch an operation from a Tamr instance by ID. This ID matches the Job ID that appears on the Jobs page in the Tamr UI.
- In TC the user-facing function `from_resource_id` has been added to the `operation` module.  
- In TUC a class method `from_resource_id` has been added to the `Operation` collection.

Closes #419 and closes #383 


## 💻 Examples

TC:
```
import tamr_client as tc

session = tc.Session(...)
job_id = "42"

op = tc.operation.from_resource_id(session, instance, job_id)
```

TUC:
```
from tamr_unify_client import Client, Operation

client = Client(...)
job_id = "42"
op = Operation.from_resource_id(client, job_id)
```
## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
