### PR TITLE
Add functionality to get, initiate and cancel Tamr backups and restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.14.0-dev
+   **BETA** 
+  Important: Do not use BETA features for production workflows.
+  - [#438](https://github.com/Datatamer/tamr-client/pull/438) Now able to get, initiate and cancel Tamr backups and restores
 
 ## 0.13.0
   **BETA** 

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -11,6 +11,7 @@
 
   * [Attribute](beta/attribute)
   * [Auth](beta/auth)
+  * [Backup](beta/backup)
   * [Categorization](beta/categorization)
   * [Dataset](beta/dataset)
   * [Golden Records](beta/golden_records)
@@ -19,6 +20,7 @@
   * [Operation](beta/operation)
   * [Primary Key](beta/primary_key)
   * [Project](beta/project)
+  * [Restore](beta/restore)
   * [Schema Mapping](beta/schema_mapping)
   * [Transformations](beta/transformations)
   * [Response](beta/response)

--- a/docs/beta/backup.rst
+++ b/docs/beta/backup.rst
@@ -7,6 +7,7 @@ Backup
 .. autofunction:: tamr_client.backup.by_resource_id
 .. autofunction:: tamr_client.backup.initiate
 .. autofunction:: tamr_client.backup.cancel
+.. autofunction:: tamr_client.backup.poll
 
 Exceptions
 ----------

--- a/docs/beta/backup.rst
+++ b/docs/beta/backup.rst
@@ -1,0 +1,17 @@
+Backup
+======
+
+.. autoclass:: tamr_client.Backup
+
+.. autofunction:: tamr_client.backup.get_all
+.. autofunction:: tamr_client.backup.by_resource_id
+.. autofunction:: tamr_client.backup.initiate
+.. autofunction:: tamr_client.backup.cancel
+
+Exceptions
+----------
+
+.. autoclass:: tamr_client.backup.NotFound
+  :no-inherited-members:
+.. autoclass:: tamr_client.backup.InvalidOperation
+  :no-inherited-members:

--- a/docs/beta/restore.rst
+++ b/docs/beta/restore.rst
@@ -1,0 +1,16 @@
+Restore
+=======
+
+.. autoclass:: tamr_client.Restore
+
+.. autofunction:: tamr_client.restore.get
+.. autofunction:: tamr_client.restore.initiate
+.. autofunction:: tamr_client.restore.cancel
+
+Exceptions
+----------
+
+.. autoclass:: tamr_client.restore.NotFound
+  :no-inherited-members:
+.. autoclass:: tamr_client.restore.InvalidOperation
+  :no-inherited-members:

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -20,6 +20,7 @@ from tamr_client._types import (
     AnyDataset,
     Attribute,
     AttributeType,
+    Backup,
     CategorizationProject,
     Dataset,
     GoldenRecordsProject,
@@ -28,6 +29,7 @@ from tamr_client._types import (
     MasteringProject,
     Operation,
     Project,
+    Restore,
     SchemaMappingProject,
     Session,
     SubAttribute,
@@ -41,6 +43,7 @@ from tamr_client._types import (
 ###############
 
 from tamr_client import attribute
+from tamr_client import backup
 from tamr_client import categorization
 from tamr_client import dataset
 from tamr_client import golden_records
@@ -50,6 +53,7 @@ from tamr_client import operation
 from tamr_client import primary_key
 from tamr_client import project
 from tamr_client import response
+from tamr_client import restore
 from tamr_client import schema_mapping
 from tamr_client import session
 from tamr_client import transformations

--- a/tamr_client/_types/__init__.py
+++ b/tamr_client/_types/__init__.py
@@ -16,6 +16,7 @@ from tamr_client._types.attribute import (
     SubAttribute,
 )
 from tamr_client._types.auth import UsernamePasswordAuth
+from tamr_client._types.backup import Backup
 from tamr_client._types.dataset import AnyDataset, Dataset, UnifiedDataset
 from tamr_client._types.instance import Instance
 from tamr_client._types.json import JsonDict
@@ -27,6 +28,7 @@ from tamr_client._types.project import (
     Project,
     SchemaMappingProject,
 )
+from tamr_client._types.restore import Restore
 from tamr_client._types.session import Session
 from tamr_client._types.transformations import InputTransformation, Transformations
 from tamr_client._types.url import URL

--- a/tamr_client/_types/backup.py
+++ b/tamr_client/_types/backup.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from tamr_client._types.url import URL
+
+
+@dataclass(frozen=True)
+class Backup:
+    """A Tamr backup
+
+    See https://docs.tamr.com/new/docs/configuration-backup-and-restore
+
+    Args:
+        url
+        resource_id
+        path
+        state
+        error_message
+    """
+
+    url: URL
+    resource_id: str
+    path: str
+    state: str
+    error_message: str

--- a/tamr_client/_types/backup.py
+++ b/tamr_client/_types/backup.py
@@ -11,14 +11,12 @@ class Backup:
 
     Args:
         url
-        resource_id
         path
         state
         error_message
     """
 
     url: URL
-    resource_id: str
     path: str
     state: str
     error_message: str

--- a/tamr_client/_types/restore.py
+++ b/tamr_client/_types/restore.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from tamr_client._types.url import URL
+
+
+@dataclass(frozen=True)
+class Restore:
+    """A Tamr restore
+
+    See https://docs.tamr.com/new/docs/configuration-backup-and-restore
+
+    Args:
+        url
+        resource_id
+        backup_path
+        state
+        error_message
+    """
+
+    url: URL
+    resource_id: str
+    backup_path: str
+    state: str
+    error_message: str

--- a/tamr_client/_types/restore.py
+++ b/tamr_client/_types/restore.py
@@ -11,14 +11,12 @@ class Restore:
 
     Args:
         url
-        resource_id
         backup_path
         state
         error_message
     """
 
     url: URL
-    resource_id: str
     backup_path: str
     state: str
     error_message: str

--- a/tamr_client/backup.py
+++ b/tamr_client/backup.py
@@ -125,3 +125,26 @@ def cancel(session: Session, backup: Backup) -> Backup:
     if r.status_code == 400:
         raise InvalidOperation(cancel_url, r.json()["message"])
     return _from_json(backup.url, response.successful(r).json())
+
+
+def poll(session: Session, backup: Backup) -> Backup:
+    """Poll this backup for server-side updates.
+
+    Does not update the :class:`~tamr_client.backup.Backup` object.
+    Instead, returns a new :class:`~tamr_client.backup.Backup`.
+
+    Args:
+        session: Tamr session
+        backup: Tamr backup to be polled
+
+    Returns:
+        A Tamr backup
+
+    Raises:
+        backup.NotFound: If no backup found at the specified URL
+    """
+    url = backup.url
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    return _from_json(url, response.successful(r).json())

--- a/tamr_client/backup.py
+++ b/tamr_client/backup.py
@@ -30,7 +30,6 @@ def _from_json(url: URL, data: JsonDict) -> Backup:
     cp = deepcopy(data)
     return Backup(
         url=url,
-        resource_id=cp["relativeId"],
         path=cp["backupPath"],
         state=cp["state"],
         error_message=cp["errorMessage"],
@@ -119,10 +118,10 @@ def cancel(session: Session, backup: Backup) -> Backup:
         backup.NotFound: If no backup found at the specified URL
         backup.InvalidOperation: If attempting an invalid operation
     """
-    r = session.post(f"{backup.url}:cancel")
+    cancel_url = f"{backup.url}:cancel"
+    r = session.post(cancel_url)
     if r.status_code == 404:
-        raise NotFound(f"{backup.url}:cancel")
+        raise NotFound(cancel_url)
     if r.status_code == 400:
-        raise InvalidOperation(f"{backup.url}:cancel", r.json()["message"])
-
+        raise InvalidOperation(cancel_url, r.json()["message"])
     return _from_json(backup.url, response.successful(r).json())

--- a/tamr_client/backup.py
+++ b/tamr_client/backup.py
@@ -1,0 +1,128 @@
+from copy import deepcopy
+from typing import List
+
+from tamr_client import Backup, response
+from tamr_client._types import Instance, JsonDict, Session, URL
+from tamr_client.exception import TamrClientException
+
+
+class InvalidOperation(TamrClientException):
+    """Raised when attempting an invalid operation.
+    """
+
+    pass
+
+
+class NotFound(TamrClientException):
+    """Raised when referencing a backup that does not exist on the server.
+    """
+
+    pass
+
+
+def _from_json(url: URL, data: JsonDict) -> Backup:
+    """Make backup from JSON data (deserialize).
+
+    Args:
+        url: Backup URL
+        data: Backup JSON data from Tamr server
+    """
+    cp = deepcopy(data)
+    return Backup(
+        url=url,
+        resource_id=cp["relativeId"],
+        path=cp["backupPath"],
+        state=cp["state"],
+        error_message=cp["errorMessage"],
+    )
+
+
+def get_all(session: Session, instance: Instance) -> List[Backup]:
+    """Get all backups that have been initiated for a Tamr instance.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+
+    Returns:
+        A list of Tamr backups
+
+    Raises:
+        backup.NotFound: If no backup found at the specified URL
+    """
+    url = URL(instance=instance, path="backups")
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    backups = [
+        _from_json(URL(instance=instance, path=f'backups/{data["relativeId"]}'), data)
+        for data in response.successful(r).json()
+    ]
+    return backups
+
+
+def by_resource_id(session: Session, instance: Instance, resource_id: str) -> Backup:
+    """Get information on a specific Tamr backup.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+        resource_id: Resource ID of the backup
+
+    Returns:
+        A Tamr backup
+
+    Raises:
+        backup.NotFound: If no backup found at the specified URL
+    """
+    url = URL(instance=instance, path=f"backups/{resource_id}")
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    return _from_json(url, response.successful(r).json())
+
+
+def initiate(session: Session, instance: Instance) -> Backup:
+    """Initiate a Tamr backup.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+
+    Returns:
+        Initiated backup
+
+    Raises:
+        backup.InvalidOperation: If attempting an invalid operation
+    """
+    url = URL(instance=instance, path="backups")
+    r = session.post(str(url))
+    if r.status_code == 400:
+        raise InvalidOperation(str(url), r.json()["message"])
+    data = response.successful(r).json()
+    return _from_json(
+        URL(instance=instance, path=f'backups/{data["relativeId"]}'), data
+    )
+
+
+def cancel(session: Session, backup: Backup) -> Backup:
+    """Cancel a Tamr backup.
+
+    Args:
+        session: Tamr session
+        backup: A Tamr backup
+
+    Returns:
+        Canceled backup
+
+    Raises:
+        backup.NotFound: If no backup found at the specified URL
+        backup.InvalidOperation: If attempting an invalid operation
+    """
+    r = session.post(f"{backup.url}:cancel")
+    if r.status_code == 404:
+        raise NotFound(f"{backup.url}:cancel")
+    if r.status_code == 400:
+        raise InvalidOperation(f"{backup.url}:cancel", r.json()["message"])
+
+    return _from_json(backup.url, response.successful(r).json())

--- a/tamr_client/restore.py
+++ b/tamr_client/restore.py
@@ -26,7 +26,6 @@ def _from_json(url: URL, data: JsonDict) -> Restore:
     """
     return Restore(
         url=url,
-        resource_id=data["relativeId"],
         backup_path=data["backupPath"],
         state=data["state"],
         error_message=data["errorMessage"],
@@ -88,9 +87,10 @@ def cancel(session: Session, restore: Restore) -> Restore:
         restore.NotFound: If no backup file found at the specified path
         restore.InvalidOperation: If attempting an invalid operation
     """
-    r = session.post(f"{restore.url}:cancel")
+    cancel_url = f"{restore.url}:cancel"
+    r = session.post(cancel_url)
     if r.status_code == 404:
-        raise NotFound(str(restore.url))
+        raise NotFound(cancel_url)
     if r.status_code == 400:
-        raise InvalidOperation(str(restore.url), r.json()["message"])
+        raise InvalidOperation(cancel_url, r.json()["message"])
     return _from_json(restore.url, response.successful(r).json())

--- a/tamr_client/restore.py
+++ b/tamr_client/restore.py
@@ -1,0 +1,96 @@
+from tamr_client import response, Restore
+from tamr_client._types import Instance, JsonDict, Session, URL
+from tamr_client.exception import TamrClientException
+
+
+class InvalidOperation(TamrClientException):
+    """Raised when attempting an invalid operation.
+    """
+
+    pass
+
+
+class NotFound(TamrClientException):
+    """Raised when referencing a restore that does not exist on the server.
+    """
+
+    pass
+
+
+def _from_json(data: JsonDict) -> Restore:
+    """Make restore from JSON data (deserialize).
+
+    Args:
+        data: Restore JSON data from Tamr server
+    """
+    return Restore(
+        url=data["id"],
+        resource_id=data["relativeId"],
+        backup_path=data["backupPath"],
+        state=data["state"],
+        error_message=data["errorMessage"],
+    )
+
+
+def get(session: Session, instance: Instance) -> Restore:
+    """Get information on the latest Tamr restore, if any.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+
+    Returns:
+        Latest Tamr restore
+
+    Raises:
+        restore.NotFound: If no backup found at the specified URL
+    """
+    url = URL(instance=instance, path="instance/restore")
+    r = session.get(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    return response.successful(r).json()
+
+
+def initiate(session: Session, instance: Instance, backup_path: str) -> Restore:
+    """Initiate a Tamr restore.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+        backup_path: Path to the backup
+
+    Returns:
+        Initiated restore
+
+    Raises:
+        restore.InvalidOperation: If attempting an invalid operation
+    """
+    url = URL(instance=instance, path="instance/restore")
+    r = session.post(str(url), data=backup_path)
+    if r.status_code == 400:
+        raise InvalidOperation(str(url), r.json()["message"])
+    return _from_json(response.successful(r).json())
+
+
+def cancel(session: Session, instance: Instance) -> Restore:
+    """Cancel a Tamr restore.
+
+    Args:
+        session: Tamr session
+        instance: Tamr instance
+
+    Returns:
+        Canceled restore
+
+    Raises:
+        restore.NotFound: If no backup file found at the specified path
+        restore.InvalidOperation: If attempting an invalid operation
+    """
+    url = URL(instance=instance, path="instance/restore:cancel")
+    r = session.post(str(url))
+    if r.status_code == 404:
+        raise NotFound(str(url))
+    if r.status_code == 400:
+        raise InvalidOperation(str(url), r.json()["message"])
+    return _from_json(response.successful(r).json())

--- a/tests/tamr_client/fake_json/test_backup/test_by_resource_id.json
+++ b/tests/tamr_client/fake_json/test_backup/test_by_resource_id.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups/2020-08-17_21-32-10-961"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "RUNNING",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-51-57-600"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_backup/test_cancel.json
+++ b/tests/tamr_client/fake_json/test_backup/test_cancel.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "path": "backups/2020-08-17_21-32-10-961:cancel"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "CANCELED",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-51-57-600"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_backup/test_get_all.json
+++ b/tests/tamr_client/fake_json/test_backup/test_get_all.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 200,
+      "json": [
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+          "relativeId": "2020-08-17_21-32-10-961",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+          "state": "CANCELED",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-32-10-961",
+          "lastModified": "2020-08-17_21-51-57-600"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-01-205",
+          "relativeId": "2020-08-17_21-58-01-205",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-01-205",
+          "state": "RUNNING",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-58-01-205",
+          "lastModified": "2020-08-17_21-58-01-351"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-45-062",
+          "relativeId": "2020-08-17_21-58-45-062",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-45-062",
+          "state": "FAILED",
+          "stage": "",
+          "errorMessage": "A system operation is already in progress",
+          "created": "2020-08-17_21-58-45-062",
+          "lastModified": "2020-08-17_21-58-45-249"
+        }
+      ]
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_backup/test_initiate.json
+++ b/tests/tamr_client/fake_json/test_backup/test_initiate.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "path": "backups"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "PENDING",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-32-10-961"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_backup/test_poll.json
+++ b/tests/tamr_client/fake_json/test_backup/test_poll.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups/2020-08-17_21-32-10-961"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "RUNNING",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-51-57-600"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_restore/test_cancel.json
+++ b/tests/tamr_client/fake_json/test_restore/test_cancel.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "path": "instance/restore:cancel"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/restore/restore-2020-08-19_20-01-20-233",
+        "relativeId": "restore-2020-08-19_20-01-20-233",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_22-07-11-100",
+        "state": "CANCELED",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-19_20-01-20-233",
+        "lastModified": "2020-08-19_20-02-19-351"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_restore/test_get.json
+++ b/tests/tamr_client/fake_json/test_restore/test_get.json
@@ -6,8 +6,7 @@
     },
     "response": {
       "status": 200,
-      "json": [
-        {
+      "json": {
           "id": "unify://unified-data/v1/restore/restore-2020-08-19_19-57-57-366",
           "relativeId": "restore-2020-08-19_19-57-57-366",
           "user": "admin",
@@ -17,8 +16,7 @@
           "errorMessage": "",
           "created": "2020-08-19_19-57-57-366",
           "lastModified": "2020-08-19_19-57-57-508"
-        }
-      ]
+      }
     }
   }
 ]

--- a/tests/tamr_client/fake_json/test_restore/test_get.json
+++ b/tests/tamr_client/fake_json/test_restore/test_get.json
@@ -1,0 +1,24 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "instance/restore"
+    },
+    "response": {
+      "status": 200,
+      "json": [
+        {
+          "id": "unify://unified-data/v1/restore/restore-2020-08-19_19-57-57-366",
+          "relativeId": "restore-2020-08-19_19-57-57-366",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_22-07-11-100",
+          "state": "RUNNING",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-19_19-57-57-366",
+          "lastModified": "2020-08-19_19-57-57-508"
+        }
+      ]
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_restore/test_initiate.json
+++ b/tests/tamr_client/fake_json/test_restore/test_initiate.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "path": "instance/restore"
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "id": "unify://unified-data/v1/restore/restore-2020-08-19_20-01-20-233",
+        "relativeId": "restore-2020-08-19_20-01-20-233",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_22-07-11-100",
+        "state": "PENDING",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-19_20-01-20-233",
+        "lastModified": "2020-08-19_20-01-20-233"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/test_backup.py
+++ b/tests/tamr_client/test_backup.py
@@ -35,7 +35,7 @@ def test_cancel():
         "relativeId": "2020-08-17_21-32-10-961",
         "user": "admin",
         "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
-        "state": "CANCELED",
+        "state": "RUNNING",
         "stage": "",
         "errorMessage": "",
         "created": "2020-08-17_21-32-10-961",

--- a/tests/tamr_client/test_backup.py
+++ b/tests/tamr_client/test_backup.py
@@ -46,3 +46,24 @@ def test_cancel():
     )
 
     tc.backup.cancel(session=s, backup=backup)
+
+
+@fake.json
+def test_poll():
+    s = fake.session()
+    data = {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "RUNNING",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-51-57-600",
+    }
+    backup = tc.backup._from_json(
+        url=tc.URL(path="backups/2020-08-17_21-32-10-961"), data=data
+    )
+
+    tc.backup.poll(session=s, backup=backup)

--- a/tests/tamr_client/test_backup.py
+++ b/tests/tamr_client/test_backup.py
@@ -1,0 +1,48 @@
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_get_all():
+    s = fake.session()
+    instance = fake.instance()
+
+    tc.backup.get_all(session=s, instance=instance)
+
+
+@fake.json
+def test_by_resource_id():
+    s = fake.session()
+    instance = fake.instance()
+    resource_id = "2020-08-17_21-32-10-961"
+
+    tc.backup.by_resource_id(session=s, instance=instance, resource_id=resource_id)
+
+
+@fake.json
+def test_initiate():
+    s = fake.session()
+    instance = fake.instance()
+
+    tc.backup.initiate(session=s, instance=instance)
+
+
+@fake.json
+def test_cancel():
+    s = fake.session()
+    data = {
+        "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+        "relativeId": "2020-08-17_21-32-10-961",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+        "state": "CANCELED",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-17_21-32-10-961",
+        "lastModified": "2020-08-17_21-51-57-600",
+    }
+    backup = tc.backup._from_json(
+        url=tc.URL(path="backups/2020-08-17_21-32-10-961"), data=data
+    )
+
+    tc.backup.cancel(session=s, backup=backup)

--- a/tests/tamr_client/test_restore.py
+++ b/tests/tamr_client/test_restore.py
@@ -1,0 +1,27 @@
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_get():
+    s = fake.session()
+    instance = fake.instance()
+
+    tc.restore.get(session=s, instance=instance)
+
+
+@fake.json
+def test_initiate():
+    s = fake.session()
+    instance = fake.instance()
+    backup_path = "2020-08-19_20-01-20-233"
+
+    tc.restore.initiate(session=s, instance=instance, backup_path=backup_path)
+
+
+@fake.json
+def test_cancel():
+    s = fake.session()
+    instance = fake.instance()
+
+    tc.restore.cancel(session=s, instance=instance)

--- a/tests/tamr_client/test_restore.py
+++ b/tests/tamr_client/test_restore.py
@@ -27,7 +27,7 @@ def test_cancel():
         "relativeId": "restore-2020-08-19_20-01-20-233",
         "user": "admin",
         "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_22-07-11-100",
-        "state": "CANCELED",
+        "state": "RUNNING",
         "stage": "",
         "errorMessage": "",
         "created": "2020-08-19_20-01-20-233",

--- a/tests/tamr_client/test_restore.py
+++ b/tests/tamr_client/test_restore.py
@@ -22,6 +22,17 @@ def test_initiate():
 @fake.json
 def test_cancel():
     s = fake.session()
-    instance = fake.instance()
+    data = {
+        "id": "unify://unified-data/v1/restore/restore-2020-08-19_20-01-20-233",
+        "relativeId": "restore-2020-08-19_20-01-20-233",
+        "user": "admin",
+        "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_22-07-11-100",
+        "state": "CANCELED",
+        "stage": "",
+        "errorMessage": "",
+        "created": "2020-08-19_20-01-20-233",
+        "lastModified": "2020-08-19_20-02-19-351",
+    }
+    restore = tc.restore._from_json(url=tc.URL(path="instance/restore"), data=data)
 
-    tc.restore.cancel(session=s, instance=instance)
+    tc.restore.cancel(session=s, restore=restore)


### PR DESCRIPTION
# ↪️ Pull Request

Resolves #313
Add functionality to initiate, get, and cancel Tamr backups and restores. 

## 💻 Examples

```
tamr_client.instance.backup.get(...)
tamr_client.instance.backup.get_by_id(..., backup_id="")
tamr_client.instance.backup.initiate(...)
tamr_client.instance.backup.cancel(..., backup_id="")
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
