### PR TITLE
Dataset CRUD + Project List Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   - [#445](https://github.com/Datatamer/tamr-client/pull/445) Added functions for getting projects and datasets by name via `tc.project.by_name` and `tc.dataset.by_name`
     - Renamed functions `from_resource_id` to `by_resource_id` in `tc.attribute`, `tc.dataset`, `tc.operation`, and `tc.project`
   - [#446](https://github.com/Datatamer/tamr-client/pull/446) Added functions for categorization workflow operations in `tc.categorization` and schema mapping workflow operations in `tc.schema_mapping`
+  - [#452](https://github.com/Datatamer/tamr-client/pull/452) Added functions for creating and deleting a dataset via `tc.dataset.create` and `tc.dataset.delete`
+    - Added function for deleting all records in a dataset via `tc.record.delete_all`
+    - Added functions for getting all datasets and projects in a Tamr instance via `get_all` functions in `tc.dataset` and `tc.project`
   
   **NEW FEATURES**
   - [#383](https://github.com/Datatamer/tamr-client/issues/383) Now able to create an Operation from Job resource id

--- a/docs/beta/dataset/dataset.rst
+++ b/docs/beta/dataset/dataset.rst
@@ -8,6 +8,7 @@ Dataset
 .. autofunction:: tamr_client.dataset.attributes
 .. autofunction:: tamr_client.dataset.materialize
 .. autofunction:: tamr_client.dataset.delete
+.. autofunction:: tamr_client.dataset.get_all
 
 Exceptions
 ----------

--- a/docs/beta/dataset/dataset.rst
+++ b/docs/beta/dataset/dataset.rst
@@ -19,3 +19,6 @@ Exceptions
 
 .. autoclass:: tamr_client.dataset.Ambiguous
   :no-inherited-members:
+
+.. autoclass:: tamr_client.dataset.AlreadyExists
+  :no-inherited-members:

--- a/docs/beta/dataset/dataset.rst
+++ b/docs/beta/dataset/dataset.rst
@@ -9,6 +9,7 @@ Dataset
 .. autofunction:: tamr_client.dataset.materialize
 .. autofunction:: tamr_client.dataset.delete
 .. autofunction:: tamr_client.dataset.get_all
+.. autofunction:: tamr_client.dataset.create
 
 Exceptions
 ----------

--- a/docs/beta/dataset/dataset.rst
+++ b/docs/beta/dataset/dataset.rst
@@ -7,6 +7,7 @@ Dataset
 .. autofunction:: tamr_client.dataset.by_name
 .. autofunction:: tamr_client.dataset.attributes
 .. autofunction:: tamr_client.dataset.materialize
+.. autofunction:: tamr_client.dataset.delete
 
 Exceptions
 ----------

--- a/docs/beta/dataset/record.rst
+++ b/docs/beta/dataset/record.rst
@@ -8,3 +8,4 @@ Record
 .. autofunction:: tamr_client.record.delete
 .. autofunction:: tamr_client.record._update
 .. autofunction:: tamr_client.record.stream
+.. autofunction:: tamr_client.record.delete_all

--- a/docs/beta/project.rst
+++ b/docs/beta/project.rst
@@ -3,6 +3,7 @@ Project
 
 .. autofunction:: tamr_client.project.by_resource_id
 .. autofunction:: tamr_client.project.by_name
+.. autofunction:: tamr_client.project.get_all
 
 Exceptions
 ----------

--- a/tamr_client/attribute/_attribute.py
+++ b/tamr_client/attribute/_attribute.py
@@ -149,8 +149,8 @@ def create(
         The newly created attribute
 
     Raises:
-        ReservedName: If attribute name is reserved.
-        AlreadyExists: If an attribute already exists at the specified URL.
+        attribute.ReservedName: If attribute name is reserved.
+        attribute.AlreadyExists: If an attribute already exists at the specified URL.
             Corresponds to a 409 HTTP error.
         requests.HTTPError: If any other HTTP error is encountered.
     """

--- a/tamr_client/categorization/project.py
+++ b/tamr_client/categorization/project.py
@@ -44,7 +44,7 @@ def create(
         Project created in Tamr
 
     Raises:
-        attribute.AlreadyExists: If a project with these specifications already exists
+        project.AlreadyExists: If a project with these specifications already exists
         requests.HTTPError: If any other HTTP error is encountered
     """
     return project._create(

--- a/tamr_client/dataset/__init__.py
+++ b/tamr_client/dataset/__init__.py
@@ -1,6 +1,7 @@
 from tamr_client.dataset import dataframe, record, unified
 from tamr_client.dataset._dataset import (
     _materialize_async,
+    AlreadyExists,
     Ambiguous,
     attributes,
     by_name,

--- a/tamr_client/dataset/__init__.py
+++ b/tamr_client/dataset/__init__.py
@@ -6,6 +6,7 @@ from tamr_client.dataset._dataset import (
     by_name,
     by_resource_id,
     delete,
+    get_all,
     materialize,
     NotFound,
 )

--- a/tamr_client/dataset/__init__.py
+++ b/tamr_client/dataset/__init__.py
@@ -5,6 +5,7 @@ from tamr_client.dataset._dataset import (
     attributes,
     by_name,
     by_resource_id,
+    delete,
     materialize,
     NotFound,
 )

--- a/tamr_client/dataset/__init__.py
+++ b/tamr_client/dataset/__init__.py
@@ -5,6 +5,7 @@ from tamr_client.dataset._dataset import (
     attributes,
     by_name,
     by_resource_id,
+    create,
     delete,
     get_all,
     materialize,

--- a/tamr_client/dataset/_dataset.py
+++ b/tamr_client/dataset/_dataset.py
@@ -213,3 +213,44 @@ def get_all(
         dataset = _from_json(dataset_url, dataset_json)
         datasets.append(dataset)
     return tuple(datasets)
+
+
+def create(
+    session: Session,
+    instance: Instance,
+    *,
+    name: str,
+    key_attribute_names: Tuple[str, ...],
+    description: Optional[str] = None,
+    external_id: Optional[str] = None,
+) -> Dataset:
+    """Create a dataset in Tamr.
+
+    Args:
+        instance: Tamr instance
+        name: Dataset name
+        key_attribute_names: Dataset primary key attribute names
+        description: Dataset description
+        external_id: External ID of the dataset
+
+    Returns:
+        Dataset created in Tamr
+
+    Raises:
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    data = {
+        "name": name,
+        "keyAttributeNames": key_attribute_names,
+        "description": description,
+        "externalId": external_id,
+    }
+
+    dataset_url = URL(instance=instance, path="datasets")
+    r = session.post(url=str(dataset_url), json=data)
+
+    data = response.successful(r).json()
+    dataset_path = data["relativeId"]
+    dataset_url = URL(instance=instance, path=str(dataset_path))
+
+    return _by_url(session=session, url=dataset_url)

--- a/tamr_client/dataset/_dataset.py
+++ b/tamr_client/dataset/_dataset.py
@@ -157,3 +157,23 @@ def materialize(session: Session, dataset: Dataset) -> Operation:
 def _materialize_async(session: Session, dataset: Dataset) -> Operation:
     r = session.post(str(dataset.url) + ":refresh",)
     return operation._from_response(dataset.url.instance, r)
+
+
+def delete(session: Session, dataset: Dataset, *, cascade: bool = False):
+    """Deletes an existing dataset
+
+    Sends a deletion request to the Tamr server
+
+    Args:
+        dataset: Existing dataset to delete
+        cascade: Whether to delete all derived datasets as well
+
+    Raises:
+        dataset.NotFound: If no dataset could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    r = session.delete(str(dataset.url), params={"cascade": cascade},)
+    if r.status_code == 404:
+        raise NotFound(str(dataset.url))
+    response.successful(r)

--- a/tamr_client/dataset/record.py
+++ b/tamr_client/dataset/record.py
@@ -149,3 +149,13 @@ def stream(session: Session, dataset: AnyDataset) -> Iterator[JsonDict]:
     """
     with session.get(str(dataset.url) + "/records", stream=True) as r:
         return response.ndjson(r)
+
+
+def delete_all(session: Session, dataset: AnyDataset):
+    """Delete all records in this dataset
+
+    Args:
+        dataset: Dataset from which to delete records
+    """
+    r = session.delete(str(dataset.url) + "/records")
+    response.successful(r)

--- a/tamr_client/mastering/project.py
+++ b/tamr_client/mastering/project.py
@@ -42,7 +42,7 @@ def create(
         Project created in Tamr
 
     Raises:
-        AlreadyExists: If a project with these specifications already exists.
+        project.AlreadyExists: If a project with these specifications already exists.
         requests.HTTPError: If any other HTTP error is encountered.
     """
     return project._create(

--- a/tamr_client/operation.py
+++ b/tamr_client/operation.py
@@ -128,7 +128,7 @@ def _by_url(session: Session, url: URL) -> Operation:
         url: Operation URL
 
     Raises:
-        OperationNotFound: If no operation could be found at the specified URL.
+        operation.NotFound: If no operation could be found at the specified URL.
             Corresponds to a 404 HTTP error.
         requests.HTTPError: If any other HTTP error is encountered.
     """

--- a/tamr_client/project.py
+++ b/tamr_client/project.py
@@ -82,7 +82,7 @@ def _by_url(session: Session, url: URL) -> Project:
         url: Project URL
 
     Raises:
-        NotFound: If no project could be found at the specified URL.
+        project.NotFound: If no project could be found at the specified URL.
             Corresponds to a 404 HTTP error.
         requests.HTTPError: If any other HTTP error is encountered.
     """
@@ -133,7 +133,7 @@ def _create(
         Project created in Tamr
 
     Raises:
-        AlreadyExists: If a project with these specifications already exists.
+        project.AlreadyExists: If a project with these specifications already exists.
         requests.HTTPError: If any other HTTP error is encountered.
     """
     if not unified_dataset_name:

--- a/tamr_client/schema_mapping/project.py
+++ b/tamr_client/schema_mapping/project.py
@@ -44,7 +44,7 @@ def create(
         Project created in Tamr
 
     Raises:
-        AlreadyExists: If a project with these specifications already exists.
+        project.AlreadyExists: If a project with these specifications already exists.
         requests.HTTPError: If any other HTTP error is encountered.
     """
     return project._create(

--- a/tests/tamr_client/dataset/test_dataset.py
+++ b/tests/tamr_client/dataset/test_dataset.py
@@ -179,3 +179,18 @@ def test_create():
     assert dataset.name == "new dataset"
     assert dataset.description == "a new dataset"
     assert dataset.key_attribute_names == ("primary_key",)
+
+
+@fake.json
+def test_create_dataset_already_exists():
+    s = fake.session()
+    instance = fake.instance()
+
+    with pytest.raises(tc.dataset.AlreadyExists):
+        tc.dataset.create(
+            s,
+            instance,
+            name="new dataset",
+            key_attribute_names=("primary_key",),
+            description="a new dataset",
+        )

--- a/tests/tamr_client/dataset/test_dataset.py
+++ b/tests/tamr_client/dataset/test_dataset.py
@@ -84,3 +84,28 @@ def test_materialize_async():
         "endTime": "",
         "message": "Job has not yet been submitted to Spark",
     }
+
+
+@fake.json
+def test_delete():
+    s = fake.session()
+    dataset = fake.dataset()
+
+    tc.dataset.delete(s, dataset)
+
+
+@fake.json
+def test_delete_cascading():
+    s = fake.session()
+    dataset = fake.dataset()
+
+    tc.dataset.delete(s, dataset, cascade=True)
+
+
+@fake.json
+def test_delete_dataset_not_found():
+    s = fake.session()
+    dataset = fake.dataset()
+
+    with pytest.raises(tc.dataset.NotFound):
+        tc.dataset.delete(s, dataset)

--- a/tests/tamr_client/dataset/test_dataset.py
+++ b/tests/tamr_client/dataset/test_dataset.py
@@ -109,3 +109,56 @@ def test_delete_dataset_not_found():
 
     with pytest.raises(tc.dataset.NotFound):
         tc.dataset.delete(s, dataset)
+
+
+@fake.json
+def test_get_all():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_datasets = tc.dataset.get_all(s, instance)
+    assert len(all_datasets) == 2
+
+    dataset_1 = all_datasets[0]
+    assert dataset_1.name == "dataset 1 name"
+    assert dataset_1.description == "dataset 1 description"
+    assert dataset_1.key_attribute_names == ("tamr_id",)
+
+    dataset_2 = all_datasets[1]
+    assert dataset_2.name == "dataset 2 name"
+    assert dataset_2.description == "dataset 2 description"
+    assert dataset_2.key_attribute_names == ("tamr_id",)
+
+
+@fake.json
+def test_get_all_filter():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_datasets = tc.dataset.get_all(
+        s, instance, filter="description==dataset 2 description"
+    )
+    assert len(all_datasets) == 1
+
+    dataset = all_datasets[0]
+    assert dataset.name == "dataset 2 name"
+    assert dataset.description == "dataset 2 description"
+    assert dataset.key_attribute_names == ("tamr_id",)
+
+
+@fake.json
+def test_get_all_filter_list():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_datasets = tc.dataset.get_all(
+        s,
+        instance,
+        filter=["description==dataset 2 description", "version==dataset 2 version"],
+    )
+    assert len(all_datasets) == 1
+
+    dataset = all_datasets[0]
+    assert dataset.name == "dataset 2 name"
+    assert dataset.description == "dataset 2 description"
+    assert dataset.key_attribute_names == ("tamr_id",)

--- a/tests/tamr_client/dataset/test_dataset.py
+++ b/tests/tamr_client/dataset/test_dataset.py
@@ -162,3 +162,20 @@ def test_get_all_filter_list():
     assert dataset.name == "dataset 2 name"
     assert dataset.description == "dataset 2 description"
     assert dataset.key_attribute_names == ("tamr_id",)
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    instance = fake.instance()
+
+    dataset = tc.dataset.create(
+        s,
+        instance,
+        name="new dataset",
+        key_attribute_names=("primary_key",),
+        description="a new dataset",
+    )
+    assert dataset.name == "new dataset"
+    assert dataset.description == "a new dataset"
+    assert dataset.key_attribute_names == ("primary_key",)

--- a/tests/tamr_client/dataset/test_record.py
+++ b/tests/tamr_client/dataset/test_record.py
@@ -87,6 +87,14 @@ def test_stream():
     assert list(records) == _records_json
 
 
+@fake.json
+def test_delete_all():
+    s = fake.session()
+    dataset = fake.dataset()
+
+    tc.record.delete_all(s, dataset)
+
+
 _records_json = [{"primary_key": 1}, {"primary_key": 2}]
 
 _response_json = {

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_create.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_create.json
@@ -1,0 +1,74 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets",
+            "json": {
+                "name": "new dataset",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "description": "a new dataset",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "new dataset",
+                "description": "a new dataset",
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+        {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "new dataset",
+                "description": "a new dataset",
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_create_dataset_already_exists.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_create_dataset_already_exists.json
@@ -1,0 +1,22 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets",
+            "json": {
+                "name": "new dataset",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "description": "a new dataset",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 400,
+            "json": {
+                "message": "Dataset \"new dataset\" already exists"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_delete.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_delete.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=false"
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_delete_cascading.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_delete_cascading.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=true"
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_delete_dataset_not_found.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_delete_dataset_not_found.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=false"
+        },
+        "response": {
+            "status": 404
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all.json
@@ -1,0 +1,59 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/datasets/1",
+                    "externalId": "number 1",
+                    "name": "dataset 1 name",
+                    "description": "dataset 1 description",
+                    "version": "dataset 1 version",
+                    "keyAttributeNames": [
+                        "tamr_id"
+                    ],
+                    "tags": [],
+                    "created": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.636Z",
+                        "version": "dataset 1 created version"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.851Z",
+                        "version": "dataset 1 modified version"
+                    },
+                    "relativeId": "datasets/1",
+                    "upstreamDatasetIds": []
+                },
+                {
+                    "id": "unify://unified-data/v1/datasets/2",
+                    "externalId": "number 2",
+                    "name": "dataset 2 name",
+                    "description": "dataset 2 description",
+                    "version": "dataset 2 version",
+                    "keyAttributeNames": [
+                        "tamr_id"
+                    ],
+                    "tags": [],
+                    "created": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.636Z",
+                        "version": "dataset 2 created version"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.851Z",
+                        "version": "dataset 2 modified version"
+                    },
+                    "relativeId": "datasets/2",
+                    "upstreamDatasetIds": []
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all_filter.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all_filter.json
@@ -1,0 +1,36 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets?filter=description==dataset%202%20description"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/datasets/2",
+                    "externalId": "number 2",
+                    "name": "dataset 2 name",
+                    "description": "dataset 2 description",
+                    "version": "dataset 2 version",
+                    "keyAttributeNames": [
+                        "tamr_id"
+                    ],
+                    "tags": [],
+                    "created": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.636Z",
+                        "version": "dataset 2 created version"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.851Z",
+                        "version": "dataset 2 modified version"
+                    },
+                    "relativeId": "datasets/2",
+                    "upstreamDatasetIds": []
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all_filter_list.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataset/test_get_all_filter_list.json
@@ -1,0 +1,36 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets?filter=description==dataset%202%20description&?filter=version==dataset%202%20version"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/datasets/2",
+                    "externalId": "number 2",
+                    "name": "dataset 2 name",
+                    "description": "dataset 2 description",
+                    "version": "dataset 2 version",
+                    "keyAttributeNames": [
+                        "tamr_id"
+                    ],
+                    "tags": [],
+                    "created": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.636Z",
+                        "version": "dataset 2 created version"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2018-09-10T16:06:20.851Z",
+                        "version": "dataset 2 modified version"
+                    },
+                    "relativeId": "datasets/2",
+                    "upstreamDatasetIds": []
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_record/test_delete_all.json
+++ b/tests/tamr_client/fake_json/dataset/test_record/test_delete_all.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1/records"
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/test_project/test_get_all.json
+++ b/tests/tamr_client/fake_json/test_project/test_get_all.json
@@ -1,0 +1,51 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/projects/1",
+                    "name": "project 1",
+                    "description": "Mastering Project",
+                    "type": "DEDUP",
+                    "unifiedDatasetName": "project_1_unified_dataset",
+                    "created": {
+                        "username": "admin",
+                        "time": "2020-04-03T14:14:18.752Z",
+                        "version": "18"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2020-04-03T14:14:20.115Z",
+                        "version": "19"
+                    },
+                    "relativeId": "projects/1",
+                    "externalId": "58bdbe72-3c08-427d-97bd-45b16d92c79c"
+                },
+                {
+                    "id": "unify://unified-data/v1/projects/2",
+                    "name": "project 2",
+                    "description": "Categorization Project",
+                    "type": "CATEGORIZATION",
+                    "unifiedDatasetName": "project_2_unified_dataset",
+                    "created": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "20"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "21"
+                    },
+                    "relativeId": "projects/2",
+                    "externalId": "98f9e4ee-1a35-4242-917d-1163363d5411"
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/test_project/test_get_all_filter.json
+++ b/tests/tamr_client/fake_json/test_project/test_get_all_filter.json
@@ -1,0 +1,32 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects?filter=description==Categorization%20Project"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/projects/2",
+                    "name": "project 2",
+                    "description": "Categorization Project",
+                    "type": "CATEGORIZATION",
+                    "unifiedDatasetName": "project_2_unified_dataset",
+                    "created": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "20"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "21"
+                    },
+                    "relativeId": "projects/2",
+                    "externalId": "98f9e4ee-1a35-4242-917d-1163363d5411"
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/test_project/test_get_all_filter_list.json
+++ b/tests/tamr_client/fake_json/test_project/test_get_all_filter_list.json
@@ -1,0 +1,32 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects?filter=description==Categorization%20Project&?filter=name==project%202"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/projects/2",
+                    "name": "project 2",
+                    "description": "Categorization Project",
+                    "type": "CATEGORIZATION",
+                    "unifiedDatasetName": "project_2_unified_dataset",
+                    "created": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "20"
+                    },
+                    "lastModified": {
+                        "username": "admin",
+                        "time": "2020-08-04T14:54:11.767Z",
+                        "version": "21"
+                    },
+                    "relativeId": "projects/2",
+                    "externalId": "98f9e4ee-1a35-4242-917d-1163363d5411"
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -61,3 +61,54 @@ def test_by_name_project_ambiguous():
 
     with pytest.raises(tc.project.Ambiguous):
         tc.project.by_name(s, instance, "ambiguous project")
+
+
+@fake.json
+def test_get_all():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_projects = tc.project.get_all(s, instance)
+    assert len(all_projects) == 2
+
+    project_1 = all_projects[0]
+    assert isinstance(project_1, tc.MasteringProject)
+    assert project_1.name == "project 1"
+    assert project_1.description == "Mastering Project"
+
+    project_2 = all_projects[1]
+    assert isinstance(project_2, tc.CategorizationProject)
+    assert project_2.name == "project 2"
+    assert project_2.description == "Categorization Project"
+
+
+@fake.json
+def test_get_all_filter():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_projects = tc.project.get_all(
+        s, instance, filter="description==Categorization Project"
+    )
+    assert len(all_projects) == 1
+
+    project = all_projects[0]
+    assert isinstance(project, tc.CategorizationProject)
+    assert project.name == "project 2"
+    assert project.description == "Categorization Project"
+
+
+@fake.json
+def test_get_all_filter_list():
+    s = fake.session()
+    instance = fake.instance()
+
+    all_projects = tc.project.get_all(
+        s, instance, filter=["description==Categorization Project", "name==project 2"]
+    )
+    assert len(all_projects) == 1
+
+    project = all_projects[0]
+    assert isinstance(project, tc.CategorizationProject)
+    assert project.name == "project 2"
+    assert project.description == "Categorization Project"


### PR DESCRIPTION
# ↪️ Pull Request

This PR closes the feature gap for Tamr dataset creation and deletion.  Additionally, it adds functionality to get the list of all datasets/projects on an instance (as `Dataset`/`Project` objects), optionally passing a filter.  The functionality to truncate a dataset (delete all records) is added via `tc.record.delete_all`.

## 💻 Examples

```python
import tamr_client as tc

session = ...
instance = ...

# Make a new dataset
new_dataset = tc.dataset.create(
    s,
    instance,
    name="My New Dataset",
    key_attribute_names=("primary_key",),
    description="A new dataset created with TC",
)
# Delete the dataset
tc.dataset.delete(s, new_dataset)

# Get all datasets
dataset_list = tc.dataset.get_all(s, instance)

# Get all projects
project_list = tc.project.get_all(s, instance)

# Get all datasets that match a filter
wobbly_dataset_list = tc.dataset.get_all(s, instance, filter="name==wobbly")

# Truncate records in a dataset
dataset = ...
tc.record.delete_all(s, dataset)
```

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
