### PR TITLE
Improve test coverage

### DIFF
--- a/tamr_client/_types/attribute.py
+++ b/tamr_client/_types/attribute.py
@@ -35,7 +35,6 @@ class SubAttribute:
 
     Args:
         name: Name of sub-attribute
-        description: Description of sub-attribute
         type: See https://docs.tamr.com/reference#attribute-types
         is_nullable: If this sub-attribute can be null
     """
@@ -43,7 +42,6 @@ class SubAttribute:
     name: str
     type: "AttributeType"
     is_nullable: bool
-    description: Optional[str] = None
 
 
 # attribute types

--- a/tamr_client/attribute/sub.py
+++ b/tamr_client/attribute/sub.py
@@ -34,6 +34,4 @@ def to_json(subattr: SubAttribute) -> JsonDict:
         "type": attribute_type.to_json(subattr.type),
         "isNullable": subattr.is_nullable,
     }
-    if subattr.description is not None:
-        d["description"] = subattr.description
     return d

--- a/tests/tamr_client/attribute/test_attribute.py
+++ b/tests/tamr_client/attribute/test_attribute.py
@@ -49,12 +49,14 @@ def test_create():
         name="attr",
         is_nullable=False,
         type=tc.attribute.type.Record(attributes=attrs),
+        description="an attribute",
     )
 
     assert attr.name == "attr"
     assert not attr.is_nullable
     assert isinstance(attr.type, tc.attribute.type.Record)
     assert attr.type.attributes == attrs
+    assert attr.description == "an attribute"
 
 
 @fake.json

--- a/tests/tamr_client/attribute/test_type.py
+++ b/tests/tamr_client/attribute/test_type.py
@@ -13,14 +13,12 @@ def test_from_json():
             assert subattr.name == "point"
             assert subattr.type == tc.attribute.type.Array(tc.attribute.type.DOUBLE)
             assert subattr.is_nullable
-            assert subattr.description is None
         elif i == 1:
             assert subattr.name == "lineString"
             assert subattr.type == tc.attribute.type.Array(
                 tc.attribute.type.Array(tc.attribute.type.DOUBLE)
             )
             assert subattr.is_nullable
-            assert subattr.description is None
         elif i == 2:
             assert subattr.name == "polygon"
             assert subattr.type == tc.attribute.type.Array(
@@ -29,7 +27,6 @@ def test_from_json():
                 )
             )
             assert subattr.is_nullable
-            assert subattr.description is None
 
 
 def test_json():

--- a/tests/tamr_client/attribute/test_type.py
+++ b/tests/tamr_client/attribute/test_type.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tamr_client as tc
 from tests.tamr_client import utils
 
@@ -27,6 +29,41 @@ def test_from_json():
                 )
             )
             assert subattr.is_nullable
+
+
+def test_from_json_missing_base_type():
+    type_json: tc._types.JsonDict = {"attributes": []}
+
+    with pytest.raises(ValueError):
+        tc.attribute.type.from_json(type_json)
+
+
+def test_from_json_unrecognized_base_type():
+    type_json: tc._types.JsonDict = {"baseType": "NOT_A_TYPE", "attributes": []}
+
+    with pytest.raises(ValueError):
+        tc.attribute.type.from_json(type_json)
+
+
+def test_from_json_array_missing_inner_type():
+    type_json: tc._types.JsonDict = {"baseType": "ARRAY"}
+
+    with pytest.raises(ValueError):
+        tc.attribute.type.from_json(type_json)
+
+
+def test_from_json_map_missing_inner_type():
+    type_json: tc._types.JsonDict = {"baseType": "MAP"}
+
+    with pytest.raises(ValueError):
+        tc.attribute.type.from_json(type_json)
+
+
+def test_from_json_record_missing_attributes():
+    type_json: tc._types.JsonDict = {"baseType": "RECORD"}
+
+    with pytest.raises(ValueError):
+        tc.attribute.type.from_json(type_json)
 
 
 def test_json():

--- a/tests/tamr_client/categorization/test_categorization_project.py
+++ b/tests/tamr_client/categorization/test_categorization_project.py
@@ -1,0 +1,18 @@
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    instance = fake.instance()
+
+    project = tc.categorization.project.create(
+        s,
+        instance,
+        name="New Categorization Project",
+        description="A Categorization Project",
+    )
+    assert isinstance(project, tc.CategorizationProject)
+    assert project.name == "New Categorization Project"
+    assert project.description == "A Categorization Project"

--- a/tests/tamr_client/fake_json/attribute/test_attribute/test_create.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute/test_create.json
@@ -50,7 +50,8 @@
                             }
                         }
                     ]
-                }
+                },
+                "description": "an attribute"
             }
         },
         "response": {
@@ -102,7 +103,8 @@
                             }
                         }
                     ]
-                }
+                },
+                "description": "an attribute"
             }
         }
     }

--- a/tests/tamr_client/fake_json/categorization/test_categorization_project/test_create.json
+++ b/tests/tamr_client/fake_json/categorization/test_categorization_project/test_create.json
@@ -1,0 +1,65 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects",
+            "json": {
+                "name": "New Categorization Project",
+                "type": "CATEGORIZATION",
+                "unifiedDatasetName": "New Categorization Project_unified_dataset",
+                "description": "A Categorization Project",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/2",
+                "name": "New Categorization Project",
+                "description": "A Categorization Project",
+                "type": "CATEGORIZATION",
+                "unifiedDatasetName": "New Categorization Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/2",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    },
+        {
+        "request": {
+            "method": "GET",
+            "path": "projects/2"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/2",
+                "name": "New Categorization Project",
+                "description": "A Categorization Project",
+                "type": "CATEGORIZATION",
+                "unifiedDatasetName": "New Categorization Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/2",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/mastering/test_mastering_project/test_create.json
+++ b/tests/tamr_client/fake_json/mastering/test_mastering_project/test_create.json
@@ -1,0 +1,65 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects",
+            "json": {
+                "name": "New Mastering Project",
+                "type": "DEDUP",
+                "unifiedDatasetName": "New Mastering Project_unified_dataset",
+                "description": "A Mastering Project",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1",
+                "name": "New Mastering Project",
+                "description": "A Mastering Project",
+                "type": "DEDUP",
+                "unifiedDatasetName": "New Mastering Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/1",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    },
+        {
+        "request": {
+            "method": "GET",
+            "path": "projects/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/1",
+                "name": "New Mastering Project",
+                "description": "A Mastering Project",
+                "type": "DEDUP",
+                "unifiedDatasetName": "New Mastering Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/1",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_schema_mapping_project/test_create.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_schema_mapping_project/test_create.json
@@ -1,0 +1,65 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects",
+            "json": {
+                "name": "New Schema Mapping Project",
+                "type": "SCHEMA_MAPPING_RECOMMENDATIONS",
+                "unifiedDatasetName": "New Schema Mapping Project_unified_dataset",
+                "description": "A Schema Mapping Project",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/3",
+                "name": "New Schema Mapping Project",
+                "description": "A Schema Mapping Project",
+                "type": "SCHEMA_MAPPING_RECOMMENDATIONS",
+                "unifiedDatasetName": "New Schema Mapping Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/3",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    },
+        {
+        "request": {
+            "method": "GET",
+            "path": "projects/3"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/projects/3",
+                "name": "New Schema Mapping Project",
+                "description": "A Schema Mapping Project",
+                "type": "SCHEMA_MAPPING_RECOMMENDATIONS",
+                "unifiedDatasetName": "New Schema Mapping Project_unified_dataset",
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "modified version"
+                },
+                "relativeId": "projects/3",
+                "externalId": "b129f3b1-82f5-4e30-90a3-e562ca977992"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/test_project/test_create_project_already_exists.json
+++ b/tests/tamr_client/fake_json/test_project/test_create_project_already_exists.json
@@ -1,0 +1,21 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects",
+            "json": {
+                "name": "New Mastering Project",
+                "type": "DEDUP",
+                "unifiedDatasetName": "New Mastering Project_unified_dataset",
+                "description": "A Mastering Project",
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 409,
+            "json": {
+                "message": "Can't create project with the requested name 'New Mastering Project' because a project with that name already exists"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/mastering/test_mastering_project.py
+++ b/tests/tamr_client/mastering/test_mastering_project.py
@@ -1,0 +1,15 @@
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    instance = fake.instance()
+
+    project = tc.mastering.project.create(
+        s, instance, name="New Mastering Project", description="A Mastering Project",
+    )
+    assert isinstance(project, tc.MasteringProject)
+    assert project.name == "New Mastering Project"
+    assert project.description == "A Mastering Project"

--- a/tests/tamr_client/schema_mapping/test_schema_mapping_project.py
+++ b/tests/tamr_client/schema_mapping/test_schema_mapping_project.py
@@ -1,0 +1,18 @@
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    instance = fake.instance()
+
+    project = tc.schema_mapping.project.create(
+        s,
+        instance,
+        name="New Schema Mapping Project",
+        description="A Schema Mapping Project",
+    )
+    assert isinstance(project, tc.SchemaMappingProject)
+    assert project.name == "New Schema Mapping Project"
+    assert project.description == "A Schema Mapping Project"

--- a/tests/tamr_client/test_auth.py
+++ b/tests/tamr_client/test_auth.py
@@ -1,0 +1,10 @@
+import tamr_client as tc
+
+
+def test_auth_hidden_password():
+    username = "username"
+    password = "secure_password"
+    auth = tc.UsernamePasswordAuth(username, password)
+
+    assert password not in repr(auth)
+    assert password not in str(auth)

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -112,3 +112,26 @@ def test_get_all_filter_list():
     assert isinstance(project, tc.CategorizationProject)
     assert project.name == "project 2"
     assert project.description == "Categorization Project"
+
+
+@fake.json
+def test_create_project_already_exists():
+    s = fake.session()
+    instance = fake.instance()
+
+    with pytest.raises(tc.project.AlreadyExists):
+        tc.project._create(
+            s,
+            instance,
+            name="New Mastering Project",
+            project_type="DEDUP",
+            description="A Mastering Project",
+        )
+
+
+def test_from_json_unrecognized_project_type():
+    instance = fake.instance()
+    url = tc.URL("project/1", instance)
+    data: tc._types.JsonDict = {"type": "NOT_A_PROJECT_TYPE"}
+    with pytest.raises(ValueError):
+        tc.project._from_json(url, data)


### PR DESCRIPTION
# ↪️ Pull Request
Quick PR to improve test coverage of `tamr_client`.

For the most part, all mock server requests are now present.  Testing is not included for the synchronous workflow functions (core asynchronous versions do have testing), since these are only meaningful when tested against a real Tamr instance.  For instance, this PR adds mock server request/response tests related to #437, but does **not** satisfy the need for end-to-end testing.

Additionally, the `description` property of `SubAttributes` has been removed to align with the restrictions on the related objects in Tamr.

```bash
---------- coverage: platform darwin, python 3.6.10-final-0 ----------
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
tamr_client/__init__.py                            20      0   100%
tamr_client/_beta.py                                9      3    67%   10-18
tamr_client/_types/__init__.py                     10      0   100%
tamr_client/_types/attribute.py                    33      0   100%
tamr_client/_types/auth.py                         14      0   100%
tamr_client/_types/dataset.py                      14      0   100%
tamr_client/_types/instance.py                      6      0   100%
tamr_client/_types/json.py                          2      0   100%
tamr_client/_types/operation.py                     8      0   100%
tamr_client/_types/project.py                      16      0   100%
tamr_client/_types/session.py                       2      0   100%
tamr_client/_types/transformations.py               9      0   100%
tamr_client/_types/url.py                          10      0   100%
tamr_client/attribute/__init__.py                   3      0   100%
tamr_client/attribute/_attribute.py                58      0   100%
tamr_client/attribute/sub.py                       13      0   100%
tamr_client/attribute/type.py                      41      2    95%   54, 86
tamr_client/categorization/__init__.py              2      0   100%
tamr_client/categorization/_categorization.py      23      7    70%   43-45, 55-56, 66-67
tamr_client/categorization/project.py               7      0   100%
tamr_client/dataset/__init__.py                     2      0   100%
tamr_client/dataset/_dataset.py                    78      2    97%   159-160
tamr_client/dataset/dataframe.py                   21      1    95%   15
tamr_client/dataset/record.py                      34      0   100%
tamr_client/dataset/unified.py                     24      2    92%   85-86
tamr_client/exception.py                            2      0   100%
tamr_client/instance.py                             7      0   100%
tamr_client/mastering/__init__.py                   2      0   100%
tamr_client/mastering/_mastering.py                49     17    65%   21-23, 32-33, 43-44, 54-55, 65-66, 76-77, 87-88, 97-98
tamr_client/mastering/project.py                    7      0   100%
tamr_client/operation.py                           46      4    91%   54, 56, 59-60
tamr_client/primary_key.py                          5      0   100%
tamr_client/project.py                             64      0   100%
tamr_client/response.py                            17      0   100%
tamr_client/schema_mapping/__init__.py              2      0   100%
tamr_client/schema_mapping/_schema_mapping.py       7      3    57%   23-25
tamr_client/schema_mapping/project.py               7      0   100%
tamr_client/session.py                              6      0   100%
tamr_client/transformations.py                     22      0   100%
-----------------------------------------------------------------------------
TOTAL                                             702     41    94%
```

## ✔️ PR Todo
- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs