### PR TITLE
Exploratory tutorial conversion to use example directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
     - Added function for deleting all records in a dataset via `tc.record.delete_all`
     - Added functions for getting all datasets and projects in a Tamr instance via `get_all` functions in `tc.dataset` and `tc.project`
   - [#454](https://github.com/Datatamer/tamr-client/pull/454) Added first `tamr_client` tutorial "Get Tamr version"
-  
+  - [#456](https://github.com/Datatamer/tamr-client/pull/456) Added first example `tamr_client` script `examples/get_tamr_version.py`
   
   **NEW FEATURES**
   - [#383](https://github.com/Datatamer/tamr-client/issues/383) Now able to create an Operation from Job resource id

--- a/docs/beta/tutorial/get_version.md
+++ b/docs/beta/tutorial/get_version.md
@@ -25,55 +25,36 @@ A `Session` carries authentication credentials derived from a username and passw
 
  - Use your username and password to create an instance of `tamr_client.UsernamePasswordAuth`.
  - Use the function `tamr_client.session.from.auth` to create a `Session`.
-```python
-from getpass import getpass
-import tamr_client as tc
-
-username = input("Tamr Username:")
-password = getpass("Tamr Password:")
-
-auth = tc.UsernamePasswordAuth(username, password)
-session = tc.session.from_auth(auth)
+```eval_rst
+.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+    :language: python
+    :lines: 1-9
 ```
 ### The Instance
 An `Instance` models the installation or instance of Tamr with which a user interacts via the Python client.
 
 - Create an `Instance` using the `protocol`, `host`, and `port` of your Tamr instance.
-```python
-protocol = "http"
-host = "localhost"
-port = 9100
-
-instance = tc.Instance(protocol=protocol, host=host, port=port)
+```eval_rst
+.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+    :language: python
+    :lines: 11-15
 ```
 ### Getting the version of Tamr
 With the `Session` and `Instance` defined, you can now interact with the API of the Tamr instance.  One simple example is fetching the version of the Tamr software running on the server.
 
 - Use the function `tc.version` and print the returned value.
 
-```python
-print(tc.version(session, instance))
+```eval_rst
+.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+    :language: python
+    :lines: 17
 ```
 
 All of the above steps can be combined into the following script `get_tamr_version.py`:
 
-```python
-from getpass import getpass
-import tamr_client as tc
-
-username = input("Tamr Username:")
-password = getpass("Tamr Password:")
-
-auth = tc.UsernamePasswordAuth(username, password)
-session = tc.session.from_auth(auth)
-
-protocol = "http"
-host = "localhost"
-port = 9100
-
-instance = tc.Instance(protocol=protocol, host=host, port=port)
-
-print(tc.version(session, instance))
+```eval_rst
+.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+    :language: python
 ```
 To run the script via command line:
 ```bash

--- a/docs/beta/tutorial/get_version.md
+++ b/docs/beta/tutorial/get_version.md
@@ -26,7 +26,7 @@ A `Session` carries authentication credentials derived from a username and passw
  - Use your username and password to create an instance of `tamr_client.UsernamePasswordAuth`.
  - Use the function `tamr_client.session.from.auth` to create a `Session`.
 ```eval_rst
-.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+.. literalinclude:: ../../../examples/get_tamr_version.py
     :language: python
     :lines: 1-9
 ```
@@ -35,17 +35,17 @@ An `Instance` models the installation or instance of Tamr with which a user inte
 
 - Create an `Instance` using the `protocol`, `host`, and `port` of your Tamr instance.
 ```eval_rst
-.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+.. literalinclude:: ../../../examples/get_tamr_version.py
     :language: python
     :lines: 11-15
 ```
 ### Getting the version of Tamr
 With the `Session` and `Instance` defined, you can now interact with the API of the Tamr instance.  One simple example is fetching the version of the Tamr software running on the server.
 
-- Use the function `tc.version` and print the returned value.
+- Use the function `tc.instance.version` and print the returned value.
 
 ```eval_rst
-.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+.. literalinclude:: ../../../examples/get_tamr_version.py
     :language: python
     :lines: 17
 ```
@@ -53,7 +53,7 @@ With the `Session` and `Instance` defined, you can now interact with the API of 
 All of the above steps can be combined into the following script `get_tamr_version.py`:
 
 ```eval_rst
-.. literalinclude:: ../../../tamr_client/examples/get_tamr_version.py
+.. literalinclude:: ../../../examples/get_tamr_version.py
     :language: python
 ```
 To run the script via command line:

--- a/examples/get_tamr_version.py
+++ b/examples/get_tamr_version.py
@@ -14,4 +14,4 @@ port = 9100
 
 instance = tc.Instance(protocol=protocol, host=host, port=port)
 
-print(tc.version(session, instance))
+print(tc.instance.version(session, instance))

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,6 +36,9 @@ def typecheck(session):
     tc = repo / "tamr_client"
     session.run("mypy", "--package", str(tc))
 
+    tc_examples = [str(x) for x in (repo / "examples").glob("**/*.py")]
+    session.run("mypy", *tc_examples)
+
     tc_tests = [str(x) for x in (repo / "tests" / "tamr_client").glob("**/*.py")]
     session.run("mypy", *tc_tests)
 

--- a/tamr_client/examples/get_tamr_version.py
+++ b/tamr_client/examples/get_tamr_version.py
@@ -1,0 +1,17 @@
+from getpass import getpass
+
+import tamr_client as tc
+
+username = input("Tamr Username:")
+password = getpass("Tamr Password:")
+
+auth = tc.UsernamePasswordAuth(username, password)
+session = tc.session.from_auth(auth)
+
+protocol = "http"
+host = "localhost"
+port = 9100
+
+instance = tc.Instance(protocol=protocol, host=host, port=port)
+
+print(tc.version(session, instance))


### PR DESCRIPTION
# ↪️ Pull Request

This PR converts the `get_version` tutorial from Markdown to reST in order to source all code-blocks from the script `tamr_client/examples/get_tamr_version.py`, which is included in the CI tasks.

This is mostly intended to illustrate how documentation that displays code from examples, as discussed in #450.

<img width="1141" alt="Screen Shot 2020-09-15 at 12 08 53 PM" src="https://user-images.githubusercontent.com/39866163/93235947-3ced9600-f74c-11ea-83c6-4e8162cbf34d.png">

## ✔️ PR Todo

- [x] Added/updated testing for this change
- [x] Included links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [x] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
