### PR TITLE
No simplejson

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -446,14 +446,6 @@ six = "*"
 tests = ["pytest", "coverage (>=3.7.1,<5.0.0)", "pytest-cov", "pytest-localserver", "flake8"]
 
 [[package]]
-category = "main"
-description = "Simple, fast, extensible JSON encoder/decoder for Python"
-name = "simplejson"
-optional = false
-python-versions = ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "3.16.0"
-
-[[package]]
 category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
@@ -549,7 +541,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "eb1a510dfdc339cc884ea39cc411306e4593c01a46c13bb15e4aaf9fff85cad5"
+content-hash = "891a70e0fce285518c0ac4b762d18e79ccc02d48163ad526d9553cc0895e26e8"
 python-versions = "^3.6.1"
 
 [metadata.files]
@@ -772,29 +764,6 @@ requests = [
 responses = [
     {file = "responses-0.10.6-py2.py3-none-any.whl", hash = "sha256:97193c0183d63fba8cd3a041c75464e4b09ea0aff6328800d1546598567dde0b"},
     {file = "responses-0.10.6.tar.gz", hash = "sha256:502d9c0c8008439cfcdef7e251f507fcfdd503b56e8c0c87c3c3e3393953f790"},
-]
-simplejson = [
-    {file = "simplejson-3.16.0-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:6c3258ffff58712818a233b9737fe4be943d306c40cf63d14ddc82ba563f483a"},
-    {file = "simplejson-3.16.0-cp27-cp27m-win32.whl", hash = "sha256:2fc546e6af49fb45b93bbe878dea4c48edc34083729c0abd09981fe55bdf7f91"},
-    {file = "simplejson-3.16.0-cp27-cp27m-win_amd64.whl", hash = "sha256:3b919fc9cf508f13b929a9b274c40786036b31ad28657819b3b9ba44ba651f50"},
-    {file = "simplejson-3.16.0-cp33-cp33m-win32.whl", hash = "sha256:3af610ee72efbe644e19d5eaad575c73fb83026192114e5f6719f4901097fce2"},
-    {file = "simplejson-3.16.0-cp33-cp33m-win_amd64.whl", hash = "sha256:fb2530b53c28f0d4d84990e945c2ebb470edb469d63e389bf02ff409012fe7c5"},
-    {file = "simplejson-3.16.0-cp34-cp34m-win32.whl", hash = "sha256:37e685986cf6f8144607f90340cff72d36acf654f3653a6c47b84c5c38d00df7"},
-    {file = "simplejson-3.16.0-cp34-cp34m-win_amd64.whl", hash = "sha256:ee9625fc8ee164902dfbb0ff932b26df112da9f871c32f0f9c1bcf20c350fe2a"},
-    {file = "simplejson-3.16.0-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:354fa32b02885e6dae925f1b5bbf842c333c1e11ea5453ddd67309dc31fdb40a"},
-    {file = "simplejson-3.16.0-cp35-cp35m-win32.whl", hash = "sha256:3dd289368bbd064974d9a5961101f080e939cbe051e6689a193c99fb6e9ac89b"},
-    {file = "simplejson-3.16.0-cp35-cp35m-win_amd64.whl", hash = "sha256:067a7177ddfa32e1483ba5169ebea1bc2ea27f224853211ca669325648ca5642"},
-    {file = "simplejson-3.16.0-cp36-cp36m-win_amd64.whl", hash = "sha256:75e3f0b12c28945c08f54350d91e624f8dd580ab74fd4f1bbea54bc6b0165610"},
-    {file = "simplejson-3.16.0.tar.gz", hash = "sha256:b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5"},
-    {file = "simplejson-3.16.0.win-amd64-py2.7.exe", hash = "sha256:495511fe5f10ccf4e3ed4fc0c48318f533654db6c47ecbc970b4ed215c791968"},
-    {file = "simplejson-3.16.0.win-amd64-py3.3.exe", hash = "sha256:d8e238f20bcf70063ee8691d4a72162bcec1f4c38f83c93e6851e72ad545dabb"},
-    {file = "simplejson-3.16.0.win-amd64-py3.4.exe", hash = "sha256:feadb95170e45f439455354904768608e356c5b174ca30b3d11b0e3f24b5c0df"},
-    {file = "simplejson-3.16.0.win-amd64-py3.5.exe", hash = "sha256:65b41a5cda006cfa7c66eabbcf96aa704a6be2a5856095b9e2fd8c293bad2b46"},
-    {file = "simplejson-3.16.0.win-amd64-py3.6.exe", hash = "sha256:c206f47cbf9f32b573c9885f0ec813d2622976cf5effcf7e472344bc2e020ac1"},
-    {file = "simplejson-3.16.0.win32-py2.7.exe", hash = "sha256:491de7acc423e871a814500eb2dcea8aa66c4a4b1b4825d18f756cdf58e370cb"},
-    {file = "simplejson-3.16.0.win32-py3.3.exe", hash = "sha256:79b129fe65fdf3765440f7a73edaffc89ae9e7885d4e2adafe6aa37913a00fbb"},
-    {file = "simplejson-3.16.0.win32-py3.4.exe", hash = "sha256:2b8cb601d9ba0381499db719ccc9dfbb2fbd16013f5ff096b1a68a4775576a04"},
-    {file = "simplejson-3.16.0.win32-py3.5.exe", hash = "sha256:2c139daf167b96f21542248f8e0a06596c9b9a7a41c162cc5c9ee9f3833c93cd"},
 ]
 six = [
     {file = "six-1.12.0-py2.py3-none-any.whl", hash = "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ include = ["tamr_client/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.6.1"
 requests = "^2.22"
-simplejson = "^3.16"
 dataclasses = "^0.6.0"
 
 [tool.poetry.dev-dependencies]

--- a/tamr_unify_client/dataset/collection.py
+++ b/tamr_unify_client/dataset/collection.py
@@ -107,9 +107,7 @@ class DatasetCollection(BaseCollection):
         data = self.client.post(self.api_path, json=creation_spec).successful().json()
         return Dataset.from_json(self.client, data)
 
-    def create_from_dataframe(
-        self, df, primary_key_name, dataset_name, ignore_nan=True
-    ):
+    def create_from_dataframe(self, df, primary_key_name, dataset_name):
         """Creates a dataset in this collection with the given name, creates an attribute for each column in the `df`
         (with `primary_key_name` as the key attribute), and upserts a record for each row of `df`.
 
@@ -125,9 +123,6 @@ class DatasetCollection(BaseCollection):
         :type primary_key_name: str
         :param dataset_name: What to name the dataset in Tamr. There cannot already be a dataset with this name.
         :type dataset_name: str
-        :param ignore_nan: Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and
-            `NaN` is in `df`, this function will fail. Optional, default is `True`.
-        :type ignore_nan: bool
         :returns: The newly created dataset.
         :rtype: :class:`~tamr_unify_client.dataset.resource.Dataset`
         :raises KeyError: If `primary_key_name` is not a column in `df`.
@@ -158,10 +153,9 @@ class DatasetCollection(BaseCollection):
             except HTTPError:
                 self._handle_creation_failure(dataset, "An attribute was not created")
 
-        records = df.to_dict(orient="records")
         try:
-            response = dataset.upsert_records(
-                records, primary_key_name, ignore_nan=ignore_nan
+            response = dataset.upsert_from_dataframe(
+                df, primary_key_name=primary_key_name
             )
         except HTTPError:
             self._handle_creation_failure(dataset, "Records could not be created")

--- a/tamr_unify_client/dataset/resource.py
+++ b/tamr_unify_client/dataset/resource.py
@@ -1,8 +1,7 @@
 from copy import deepcopy
+import json
 import os
 from typing import TYPE_CHECKING
-
-import simplejson as json
 
 from tamr_unify_client.attribute.collection import AttributeCollection
 from tamr_unify_client.base_resource import BaseResource
@@ -64,20 +63,18 @@ class Dataset(BaseResource):
         alias = self.api_path + "/attributes"
         return AttributeCollection(self.client, alias)
 
-    def _update_records(self, updates, **json_args):
+    def _update_records(self, updates):
         """Send a batch of record creations/updates/deletions to this dataset.
         You probably want to use :func:`~tamr_unify_client.dataset.resource.Dataset.upsert_records`
         or :func:`~tamr_unify_client.dataset.resource.Dataset.delete_records` instead.
 
         :param records: Each record should be formatted as specified in the `Public Docs for Dataset updates <https://docs.tamr.com/reference#modify-a-datasets-records>`_.
         :type records: iterable[dict]
-        :param `**json_args`: Arguments to pass to the JSON `dumps` function, as documented `here <https://simplejson.readthedocs.io/en/latest/#simplejson.dumps>`_.
-            Some of these, such as `indent`, may not work with Tamr.
         :returns: JSON response body from server.
         :rtype: :py:class:`dict`
         """
         stringified_updates = (
-            json.dumps(update, **json_args).encode("utf-8") for update in updates
+            json.dumps(update, allow_nan=False).encode("utf-8") for update in updates
         )
 
         return (
@@ -91,14 +88,13 @@ class Dataset(BaseResource):
         )
 
     def upsert_from_dataframe(
-        self, df: "pd.DataFrame", *, primary_key_name: str, ignore_nan: bool = True
+        self, df: "pd.DataFrame", *, primary_key_name: str
     ) -> dict:
         """Upserts a record for each row of `df` with attributes for each column in `df`.
 
         Args:
             df: The data to upsert records from.
             primary_key_name: The name of the primary key of the dataset.  Must be a column of `df`.
-            ignore_nan: Whether to convert `NaN` values to `null` before upserting records to Tamr. If `False` and `NaN` is in `df`, this function will fail. Optional, default is `True`.
 
         Returns:
             JSON response body from the server.
@@ -110,18 +106,20 @@ class Dataset(BaseResource):
         if primary_key_name not in df.columns:
             raise KeyError(f"{primary_key_name} is not an attribute of the data")
 
-        records = df.to_dict(orient="records")
-        return self.upsert_records(records, primary_key_name, ignore_nan=ignore_nan)
+        # serialize records via to_json to handle `np.nan` values
+        serialized_records = ((pk, row.to_json()) for pk, row in df.iterrows())
+        records = (
+            {primary_key_name: pk, **json.loads(row)} for pk, row in serialized_records
+        )
+        return self.upsert_records(records, primary_key_name)
 
-    def upsert_records(self, records, primary_key_name, **json_args):
+    def upsert_records(self, records, primary_key_name):
         """Creates or updates the specified records.
 
         :param records: The records to update, as dictionaries.
         :type records: iterable[dict]
         :param primary_key_name: The name of the primary key for these records, which must be a key in each record dictionary.
         :type primary_key_name: str
-        :param `**json_args`: Arguments to pass to the JSON `dumps` function, as documented `here <https://simplejson.readthedocs.io/en/latest/#simplejson.dumps>`_.
-            Some of these, such as `indent`, may not work with Tamr.
         :return: JSON response body from the server.
         :rtype: dict
         """
@@ -129,7 +127,7 @@ class Dataset(BaseResource):
             {"action": "CREATE", "recordId": record[primary_key_name], "record": record}
             for record in records
         )
-        return self._update_records(updates, **json_args)
+        return self._update_records(updates)
 
     def delete_records(self, records, primary_key_name):
         """Deletes the specified records.

--- a/tests/unit/test_dataset_records.py
+++ b/tests/unit/test_dataset_records.py
@@ -58,16 +58,20 @@ class TestDatasetRecords(TestCase):
         dataset = self.tamr.datasets.by_resource_id(self._dataset_id)
 
         records_url = f"{self._dataset_url}:updateRecords"
-        updates = TestDatasetRecords.records_to_updates(self._nan_records_json)
-
+        nan_updates = TestDatasetRecords.records_to_updates(self._nan_records_json)
+        null_updates = TestDatasetRecords.records_to_updates(self._null_records_json)
         snoop = {}
+
         responses.add_callback(
             responses.POST,
             records_url,
             partial(create_callback, snoop=snoop, status=200),
         )
 
-        self.assertRaises(ValueError, lambda: dataset._update_records(updates))
+        self.assertRaises(ValueError, lambda: dataset._update_records(nan_updates))
+        response = dataset._update_records(nan_updates, ignore_nan=True)
+        self.assertEqual(response, self._response_json)
+        self.assertEqual(snoop["payload"], TestDatasetRecords.stringify(null_updates))
 
     @responses.activate
     def test_upsert(self):


### PR DESCRIPTION
# ↪️ Pull Request

Relates to #455 

This PR explores two ways that `simplejson` could be removed from the dependency list, as described in #455.  The two commits are not really consecutive, but are instead alternatives.

1. The first commit removes `simplejson` via a breaking change, where the `_update_records`/`upsert_records` methods no longer have the `ignore_nan` parameter.  This means when using these functions, it is on the user to make sure `NaN`s are not present in the records being uploaded, though the function does use `json`'s `allow_nan=False` option to raise an error before making the destined-to-fail request to the server if `NaN`'s are present.  Handling of `NaN`s **is** present in the `upsert_from_dataframe` function, since this is the primary case where such behavior is desired.  This is done in the same was as in `tamr_client` and both does not depend on `simplejson` and is robust.

2. The second commit also removes `simplejson`, but leaves the `ignore_nan` parameter in `_update_records`/`upsert_records`.  This parameter is removed from the `upsert_from_dataframe` and `create_from_dataframe` functions, since these are changed to use the `tamr_client` DataFrame solution.  The custom implementation of `ignore_nan` for `_update_records`/`upsert_records` is simple, but limited.  While serializing JSON of each update, `allow_nan=False` is used and raised errors are handled by looking for Python `NaN` values at the **top-level** within a record.  This means that the breaking change is limited to the last of the following example updates:
```python
{
  "action": "CREATE", 
  "recordId": 1,
  "record": {"pk": 1, "attr": 42}  # Nothing to catch
}
{
  "action": "CREATE",
  "recordId": 2,
  "record": {"pk": 2, "attr": NaN}  # Caught and converted
}
{
  "action": "CREATE",
  "recordId": 2,
  "record": {"pk": 2, "attr": {"a": NaN, "b": 42}}  # Not converted, will raise ValueError
}
```  

## ✔️ PR Todo

- [ ] Added/updated testing for this change
- [ ] Included links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
- [ ] Update the [CHANGELOG](https://github.com/Datatamer/tamr-client/blob/master/CHANGELOG.md) under the current `-dev` version:
  - Add changelog entries under any that apply: **BREAKING CHANGES**, **NEW FEATURES**, **BUG FIXES**.
  - Changelog entry format: `[#<issue number>](<link to issue>) <change description>`
