### PR TITLE
TC: Create dataset from DataFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ For more see the [official docs](https://tamr-client.readthedocs.io/en/stable/).
 ## Maintainers
 
 - [Pedro Cattori](https://github.com/pcattori)
+- [Samuel Kalish](https://github.com/skalish)

--- a/docs/beta/dataset/dataframe.rst
+++ b/docs/beta/dataset/dataframe.rst
@@ -2,3 +2,4 @@ Dataframe
 =========
 
 .. autofunction:: tamr_client.dataframe.upsert
+.. autofunction:: tamr_client.dataframe.create

--- a/tamr_client/dataset/dataframe.py
+++ b/tamr_client/dataset/dataframe.py
@@ -6,13 +6,23 @@ import json
 import os
 from typing import Optional, TYPE_CHECKING
 
-from tamr_client import primary_key
-from tamr_client._types import Dataset, JsonDict, Session
+import requests
+
+from tamr_client import attribute, dataset, primary_key
+from tamr_client._types import Dataset, Instance, JsonDict, Session
 from tamr_client.dataset import record
+from tamr_client.exception import TamrClientException
 
 BUILDING_DOCS = os.environ.get("TAMR_CLIENT_DOCS") == "1"
 if TYPE_CHECKING or BUILDING_DOCS:
     import pandas as pd
+
+
+class CreationFailure(TamrClientException):
+    """Raised when a dataset could not be created from a pandas DataFrame
+    """
+
+    pass
 
 
 def upsert(
@@ -27,7 +37,8 @@ def upsert(
     Args:
         dataset: Dataset to receive record updates
         df: The DataFrame containing records to be upserted
-        primary_key_name: The primary key of the dataset.  Must be a column of `df`. By default the key_attribute_name of dataset
+        primary_key_name: The primary key of the dataset.  Must be a column of `df`. By default the
+            key_attribute_name of dataset
 
     Returns:
         JSON response body from the server
@@ -41,14 +52,7 @@ def upsert(
         primary_key_name = dataset.key_attribute_names[0]
 
     # preconditions
-    if primary_key_name in df.columns and primary_key_name == df.index.name:
-        raise primary_key.Ambiguous(
-            f"Index {primary_key_name} has the same name as column {primary_key_name}"
-        )
-    elif primary_key_name not in df.columns and primary_key_name != df.index.name:
-        raise primary_key.NotFound(
-            f"Primary key: {primary_key_name} is not DataFrame index name: {df.index.name} or in DataFrame column names: {df.columns}"
-        )
+    _check_primary_key(df, primary_key_name)
 
     # promote primary key column to index
     if primary_key_name in df.columns:
@@ -60,3 +64,122 @@ def upsert(
         {primary_key_name: pk, **json.loads(row)} for pk, row in serialized_records
     )
     return record.upsert(session, dataset, records, primary_key_name=primary_key_name)
+
+
+def create(
+    session: Session,
+    instance: Instance,
+    df: "pd.DataFrame",
+    *,
+    name: str,
+    primary_key_name: Optional[str] = None,
+    description: Optional[str] = None,
+    external_id: Optional[str] = None,
+) -> Dataset:
+    """Create a dataset in Tamr from the DataFrame `df` and creates a record from each row
+
+    All attributes other than the primary key are created as the default type array(string)
+
+    Args:
+        instance: Tamr instance
+        df: The DataFrame containing records to be upserted
+        name: Dataset name
+        primary_key_name: The primary key of the dataset. Must be a column of `df`. By default the
+            name of the index of `df`
+        description: Dataset description
+        external_id: External ID of the dataset
+
+    Returns:
+        Dataset created in Tamr
+
+    Raises:
+        dataset.AlreadyExists: If a dataset with these specifications already exists.
+        requests.HTTPError: If any other HTTP error is encountered.
+        primary_key.NotFound: If `primary_key_name` is not a column in `df` or the index of `df`
+        ValueError: If `primary_key_name` matches both a column in `df` and the index of `df`
+    """
+    # preconditions
+    if primary_key_name is None:
+        if df.index.name is not None:
+            primary_key_name = df.index.name
+        else:
+            raise primary_key.NotFound(
+                "No primary key was specified and DataFrame index is unnamed"
+            )
+    _check_primary_key(df, primary_key_name)
+
+    # dataset creation
+    try:
+        ds = dataset.create(
+            session,
+            instance,
+            name=name,
+            key_attribute_names=(primary_key_name,),
+            description=description,
+            external_id=external_id,
+        )
+    except (TamrClientException, requests.HTTPError) as e:
+        raise CreationFailure(f"Dataset was not created: {e}")
+
+    # attribute creation
+    for col in df.columns:
+        if col == primary_key_name:
+            # this attribute already exists as a key attribute
+            continue
+        try:
+            attribute.create(session, ds, name=col, is_nullable=True)
+        except (TamrClientException, requests.HTTPError) as e:
+            _handle_creation_failure(session, ds, f"An attribute was not created: {e}")
+
+    # record creation
+    try:
+        response = upsert(session, ds, df, primary_key_name=primary_key_name)
+        if not response["allCommandsSucceeded"]:
+            _handle_creation_failure(session, ds, "Some records had validation errors")
+    except (TamrClientException, requests.HTTPError) as e:
+        _handle_creation_failure(session, ds, f"Record could not be created: {e}")
+
+    # Get Dataset from server
+    return dataset._dataset._by_url(session, ds.url)
+
+
+def _handle_creation_failure(session: Session, stub_dataset: Dataset, error: str):
+    """Attempt to make `dataframe.create` atomic by deleting the created dataset in the event of
+    later failure.
+
+    However, this does not guarantee atomicity: if the request to delete the dataset fails, it will
+    not retry.
+
+    Args:
+        stub_dataset: The created dataset to delete
+        error: The error that caused dataset creation to fail
+    """
+    try:
+        dataset.delete(session, stub_dataset)
+    except requests.HTTPError:
+        raise CreationFailure(
+            f"Created dataset did not delete after an earlier error: {error}"
+        )
+    raise CreationFailure(error)
+
+
+def _check_primary_key(df: "pd.DataFrame", primary_key_name: str):
+    """Check if the primary key name uniquely identifies a column or index of the DataFrame
+
+    Args:
+        df: The DataFrame to inspect
+        primary_key_name: The index or column name to be used as the primary key
+
+    Raises:
+        primary_key.Ambiguous: If the primary key name matches both the index and a column
+        primary_key.NotFound: If the primary key name does not match the index or any column
+    """
+    if primary_key_name in df.columns and primary_key_name == df.index.name:
+        raise primary_key.Ambiguous(
+            f"Index {primary_key_name} has the same name as column {primary_key_name}"
+        )
+    elif primary_key_name not in df.columns and primary_key_name != df.index.name:
+        raise primary_key.NotFound(
+            f"Primary key: {primary_key_name} is not DataFrame index name: {df.index.name} or in"
+            f" DataFrame column names: {df.columns}"
+        )

--- a/tests/tamr_client/dataset/test_dataframe.py
+++ b/tests/tamr_client/dataset/test_dataframe.py
@@ -1,41 +1,21 @@
-from functools import partial
-from typing import Dict
-
 import pandas as pd
 import pytest
-import responses
 
 import tamr_client as tc
-from tests.tamr_client import fake, utils
+from tests.tamr_client import fake
 
 
-@responses.activate
+@fake.json
 def test_upsert():
     s = fake.session()
     dataset = fake.dataset()
-
-    url = tc.URL(path="datasets/1:updateRecords")
-    updates = [
-        tc.record._create_command(record, primary_key_name="primary_key")
-        for record in _records_json
-    ]
-    snoop: Dict = {}
-    responses.add_callback(
-        responses.POST,
-        str(url),
-        partial(
-            utils.capture_payload, snoop=snoop, status=200, response_json=_response_json
-        ),
-    )
 
     df = pd.DataFrame(_records_json)
 
     response = tc.dataframe.upsert(s, dataset, df, primary_key_name="primary_key")
     assert response == _response_json
-    assert snoop["payload"] == utils.stringify(updates)
 
 
-@responses.activate
 def test_upsert_primary_key_not_found():
     s = fake.session()
     dataset = fake.dataset()
@@ -46,50 +26,21 @@ def test_upsert_primary_key_not_found():
         tc.dataframe.upsert(s, dataset, df, primary_key_name="wrong_primary_key")
 
 
-@responses.activate
+@fake.json
 def test_upsert_infer_primary_key():
     s = fake.session()
     dataset = fake.dataset()
-
-    url = tc.URL(path="datasets/1:updateRecords")
-    updates = [
-        tc.record._create_command(record, primary_key_name="primary_key")
-        for record in _records_json
-    ]
-    snoop: Dict = {}
-    responses.add_callback(
-        responses.POST,
-        str(url),
-        partial(
-            utils.capture_payload, snoop=snoop, status=200, response_json=_response_json
-        ),
-    )
 
     df = pd.DataFrame(_records_json)
 
     response = tc.dataframe.upsert(s, dataset, df)
     assert response == _response_json
-    assert snoop["payload"] == utils.stringify(updates)
 
 
-@responses.activate
+@fake.json
 def test_upsert_index_as_primary_key():
     s = fake.session()
     dataset = fake.dataset()
-
-    url = tc.URL(path="datasets/1:updateRecords")
-    updates = [
-        tc.record._create_command(record, primary_key_name="primary_key")
-        for record in _records_with_keys_json_2
-    ]
-    snoop: Dict = {}
-    responses.add_callback(
-        responses.POST,
-        str(url),
-        partial(
-            utils.capture_payload, snoop=snoop, status=200, response_json=_response_json
-        ),
-    )
 
     df = pd.DataFrame(
         _records_json_2,
@@ -99,10 +50,8 @@ def test_upsert_index_as_primary_key():
 
     response = tc.dataframe.upsert(s, dataset, df, primary_key_name="primary_key")
     assert response == _response_json
-    assert snoop["payload"] == utils.stringify(updates)
 
 
-@responses.activate
 def test_upsert_index_column_name_collision():
     s = fake.session()
     dataset = fake.dataset()
@@ -115,6 +64,97 @@ def test_upsert_index_column_name_collision():
 
     with pytest.raises(tc.primary_key.Ambiguous):
         tc.dataframe.upsert(s, dataset, df, primary_key_name="primary_key")
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    dataset = tc.dataframe.create(
+        s, instance, df, name="df_dataset", primary_key_name="primary_key"
+    )
+    assert dataset.name == "df_dataset"
+    assert dataset.key_attribute_names == ("primary_key",)
+
+
+@fake.json
+def test_create_infer_primary_key_from_index():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(
+        _records_json_2,
+        index=[record["primary_key"] for record in _records_with_keys_json_2],
+    )
+    df.index.name = "primary_key"
+
+    dataset = tc.dataframe.create(s, instance, df, name="df_dataset")
+    assert dataset.name == "df_dataset"
+    assert dataset.key_attribute_names == ("primary_key",)
+
+
+def test_create_no_primary_key():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    with pytest.raises(tc.primary_key.NotFound):
+        tc.dataframe.create(s, instance, df, name="df_dataset")
+
+
+def test_create_primary_key_not_found():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    with pytest.raises(tc.primary_key.NotFound):
+        tc.dataframe.create(
+            s, instance, df, name="df_dataset", primary_key_name="wrong_primary_key"
+        )
+
+
+@fake.json
+def test_create_handle_attribute_failure():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    with pytest.raises(tc.dataframe.CreationFailure):
+        tc.dataframe.create(
+            s, instance, df, name="df_dataset", primary_key_name="primary_key"
+        )
+
+
+@fake.json
+def test_create_deletion_failure():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    with pytest.raises(tc.dataframe.CreationFailure):
+        tc.dataframe.create(
+            s, instance, df, name="df_dataset", primary_key_name="primary_key"
+        )
+
+
+@fake.json
+def test_create_handle_record_failure():
+    s = fake.session()
+    instance = fake.instance()
+
+    df = pd.DataFrame(_records_with_keys_json_2)
+
+    with pytest.raises(tc.dataframe.CreationFailure):
+        tc.dataframe.create(
+            s, instance, df, name="df_dataset", primary_key_name="primary_key"
+        )
 
 
 _records_json = [{"primary_key": 1}, {"primary_key": 2}]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_create.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_create.json
@@ -1,0 +1,168 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets",
+            "json": {
+                "name": "df_dataset",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "description": null,
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1/attributes",
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                }
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                },
+                "description": null
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1,
+                        "attribute": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2,
+                        "attribute": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 204,
+            "json": {
+                "numCommandsProcessed": 2,
+                "allCommandsSucceeded": true,
+                "validationErrors": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_deletion_failure.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_deletion_failure.json
@@ -4,11 +4,11 @@
             "method": "POST",
             "path": "datasets",
             "json": {
-                "name": "new dataset",
+                "name": "df_dataset",
                 "keyAttributeNames": [
                     "primary_key"
                 ],
-                "description": "a new dataset",
+                "description": null,
                 "externalId": null
             }
         },
@@ -17,8 +17,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -49,8 +49,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -69,6 +69,35 @@
                 "relativeId": "datasets/1",
                 "upstreamDatasetIds": []
             }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1/attributes",
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                }
+            }
+        },
+        "response": {
+            "status": 500,
+            "json": {}
+        }
+    },
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=false"
+        },
+        "response": {
+            "status": 500
         }
     }
 ]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_handle_attribute_failure.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_handle_attribute_failure.json
@@ -4,11 +4,11 @@
             "method": "POST",
             "path": "datasets",
             "json": {
-                "name": "new dataset",
+                "name": "df_dataset",
                 "keyAttributeNames": [
                     "primary_key"
                 ],
-                "description": "a new dataset",
+                "description": null,
                 "externalId": null
             }
         },
@@ -17,8 +17,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -49,8 +49,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -69,6 +69,35 @@
                 "relativeId": "datasets/1",
                 "upstreamDatasetIds": []
             }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1/attributes",
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                }
+            }
+        },
+        "response": {
+            "status": 500,
+            "json": {}
+        }
+    },
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=false"
+        },
+        "response": {
+            "status": 204
         }
     }
 ]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_handle_record_failure.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_handle_record_failure.json
@@ -4,11 +4,11 @@
             "method": "POST",
             "path": "datasets",
             "json": {
-                "name": "new dataset",
+                "name": "df_dataset",
                 "keyAttributeNames": [
                     "primary_key"
                 ],
-                "description": "a new dataset",
+                "description": null,
                 "externalId": null
             }
         },
@@ -17,8 +17,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -49,8 +49,8 @@
             "json": {
                 "id": "unify://unified-data/v1/datasets/1",
                 "externalId": "number 1",
-                "name": "new dataset",
-                "description": "a new dataset",
+                "name": "df_dataset",
+                "description": null,
                 "version": "dataset version",
                 "keyAttributeNames": [
                     "primary_key"
@@ -69,6 +69,73 @@
                 "relativeId": "datasets/1",
                 "upstreamDatasetIds": []
             }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1/attributes",
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                }
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                },
+                "description": null
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1,
+                        "attribute": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2,
+                        "attribute": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 500,
+            "json": {}
+        }
+    },
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "datasets/1?cascade=false"
+        },
+        "response": {
+            "status": 204
         }
     }
 ]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_infer_primary_key_from_index.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_create_infer_primary_key_from_index.json
@@ -1,0 +1,168 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets",
+            "json": {
+                "name": "df_dataset",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "description": null,
+                "externalId": null
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1/attributes",
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                }
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "name": "attribute",
+                "isNullable": true,
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING"
+                    }
+                },
+                "description": null
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1,
+                        "attribute": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2,
+                        "attribute": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 204,
+            "json": {
+                "numCommandsProcessed": 2,
+                "allCommandsSucceeded": true,
+                "validationErrors": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "df_dataset",
+                "description": null,
+                "version": "dataset version",
+                "keyAttributeNames": [
+                    "primary_key"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert.json
@@ -1,0 +1,32 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 204,
+            "json": {
+                "numCommandsProcessed": 2,
+                "allCommandsSucceeded": true,
+                "validationErrors": []
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert_index_as_primary_key.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert_index_as_primary_key.json
@@ -1,0 +1,34 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1,
+                        "attribute": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2,
+                        "attribute": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 204,
+            "json": {
+                "numCommandsProcessed": 2,
+                "allCommandsSucceeded": true,
+                "validationErrors": []
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert_infer_primary_key.json
+++ b/tests/tamr_client/fake_json/dataset/test_dataframe/test_upsert_infer_primary_key.json
@@ -1,0 +1,32 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "datasets/1:updateRecords",
+            "ndjson": [
+                {
+                    "action": "CREATE",
+                    "recordId": 1,
+                    "record": {
+                        "primary_key": 1
+                    }
+                },
+                {
+                    "action": "CREATE",
+                    "recordId": 2,
+                    "record": {
+                        "primary_key": 2
+                    }
+                }
+            ]
+        },
+        "response": {
+            "status": 204,
+            "json": {
+                "numCommandsProcessed": 2,
+                "allCommandsSucceeded": true,
+                "validationErrors": []
+            }
+        }
+    }
+]


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds functionality to `tamr_client` to allow the creation of a Tamr dataset from a `pandas` DataFrame, including:
- dataset creation
- attribute creation with all attributes created as type array(string)
- upload of all rows of the DataFrame as records

Related to #247 

## 💻 Examples
```
import pandas as pd
import tamr_client as tc

s = tc.session.from_auth(tc.UsernamePasswordAuth('username', 'password'))
instance = tc.Instance(host='10.10.0.121')

df = pd.DataFrame({"pk": [1, 2], "val": [11, 12]})

new_dataset = tc.dataframe.create(s, instance, df, name="my_dataset", primary_key_name="pk")
```

## ✔️ PR Todo

- [x] Testing for this change
- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
