### PR TITLE
TC: AttributeMapping dataclass with create/read/delete functions

### DIFF
--- a/docs/beta/dataset/record.rst
+++ b/docs/beta/dataset/record.rst
@@ -1,5 +1,5 @@
 Record
-=========
+======
 
 .. automodule:: tamr_client.record
   :no-members:

--- a/docs/beta/schema_mapping.md
+++ b/docs/beta/schema_mapping.md
@@ -2,3 +2,4 @@
 
   * [Schema Mapping](/beta/schema_mapping/schema_mapping)
   * [Project](/beta/schema_mapping/project)
+  * [Attribute Mapping](/beta/schema_mapping/attribute_mapping)

--- a/docs/beta/schema_mapping/attribute_mapping.rst
+++ b/docs/beta/schema_mapping/attribute_mapping.rst
@@ -1,0 +1,20 @@
+Attribute Mapping Project
+=========================
+
+.. autoclass:: tamr_client.AttributeMapping
+
+.. autofunction:: tamr_client.schema_mapping.attribute_mapping.get_all
+.. autofunction:: tamr_client.schema_mapping.attribute_mapping.create
+.. autofunction:: tamr_client.schema_mapping.attribute_mapping.delete
+
+Exceptions
+----------
+
+.. autoclass:: tamr_client.schema_mapping.attribute_mapping.NotFound
+  :no-inherited-members:
+
+.. autoclass:: tamr_client.schema_mapping.attribute_mapping.Ambiguous
+  :no-inherited-members:
+
+.. autoclass:: tamr_client.schema_mapping.attribute_mapping.AlreadyExists
+  :no-inherited-members:

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -19,6 +19,7 @@ _beta.check()
 from tamr_client._types import (
     AnyDataset,
     Attribute,
+    AttributeMapping,
     AttributeType,
     Backup,
     CategorizationProject,

--- a/tamr_client/_types/__init__.py
+++ b/tamr_client/_types/__init__.py
@@ -22,6 +22,7 @@ from tamr_client._types.instance import Instance
 from tamr_client._types.json import JsonDict
 from tamr_client._types.operation import Operation
 from tamr_client._types.project import (
+    AttributeMapping,
     CategorizationProject,
     GoldenRecordsProject,
     MasteringProject,

--- a/tamr_client/_types/project.py
+++ b/tamr_client/_types/project.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional, Union
 
+from tamr_client._types.attribute import Attribute
 from tamr_client._types.url import URL
 
 
@@ -96,3 +97,20 @@ Project = Union[
     GoldenRecordsProject,
     UnknownProject,
 ]
+
+
+@dataclass(frozen=True)
+class AttributeMapping:
+    """A Tamr Attribute Mapping.
+
+    See https://docs.tamr.com/new/reference/retrieve-projects-mappings
+
+    Args:
+        url
+        input_attribute
+        unified_attribute
+    """
+
+    url: URL
+    input_attribute: Attribute
+    unified_attribute: Attribute

--- a/tamr_client/schema_mapping/__init__.py
+++ b/tamr_client/schema_mapping/__init__.py
@@ -2,5 +2,5 @@
 Tamr - Schema Mapping
 See https://docs.tamr.com/new/docs/overall-workflow-schema
 """
-from tamr_client.schema_mapping import project
+from tamr_client.schema_mapping import attribute_mapping, project
 from tamr_client.schema_mapping._schema_mapping import update_unified_dataset

--- a/tamr_client/schema_mapping/attribute_mapping.py
+++ b/tamr_client/schema_mapping/attribute_mapping.py
@@ -1,0 +1,190 @@
+"""
+See https://docs.tamr.com/new/reference/retrieve-projects-mappings
+"""
+from copy import deepcopy
+from typing import Dict, List, Optional, Tuple
+
+from tamr_client import attribute, dataset, response
+from tamr_client import project as tc_project
+from tamr_client._types import (
+    Attribute,
+    AttributeMapping,
+    Instance,
+    JsonDict,
+    Project,
+    Session,
+    URL,
+)
+from tamr_client.exception import TamrClientException
+
+
+class NotFound(TamrClientException):
+    """Raised when referencing an attribute mapping that does not exist on the server."""
+
+    pass
+
+
+class AlreadyExists(TamrClientException):
+    """Raised when an attribute mapping with these specifications already exists."""
+
+    pass
+
+
+class Ambiguous(TamrClientException):
+    """Raised when an attribute mapping specification is incomplete, ambiguous, or contradictory."""
+
+    pass
+
+
+def create(
+    session: Session,
+    project: Project,
+    input_attribute: Attribute,
+    unified_attribute: Attribute,
+) -> AttributeMapping:
+    """Create a mapping in Tamr between input attributes and unified attributes of the given project.
+
+    Args:
+        project: Tamr project
+        input_attribute: The attribute of a source dataset to map
+        unified_attribute: The attribute of the unified dataset to map onto
+
+    Returns:
+        Attribute mapping created in Tamr
+
+    Raises:
+        attribute_mapping.AlreadyExists: If an attribute mapping with these specifications already exists.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    data = {
+        "relativeInputAttributeId": input_attribute.url.path,
+        "relativeUnifiedAttributeId": unified_attribute.url.path,
+    }
+    r = session.post(url=str(project.url) + "/attributeMappings", json=data)
+
+    if r.status_code == 204:
+        raise AlreadyExists(
+            "An attribute mapping with these specifications already exists."
+        )
+    if r.status_code == 400:
+        raise Ambiguous(r.json()["message"])
+    if r.status_code == 404:
+        if "dataset" in r.json()["message"].lower():
+            raise dataset.NotFound(r.json()["message"])
+        elif "project" in r.json()["message"].lower():
+            raise tc_project.NotFound(r.json()["message"])
+
+    data = response.successful(r).json()
+    instance = project.url.instance
+    url = URL(instance=instance, path=data["relativeId"])
+    return AttributeMapping(
+        url,
+        input_attribute=attribute._attribute._by_url(
+            session, URL(instance=instance, path=data["relativeInputAttributeId"]),
+        ),
+        unified_attribute=attribute._attribute._by_url(
+            session, URL(instance=instance, path=data["relativeUnifiedAttributeId"]),
+        ),
+    )
+
+
+def get_all(session: Session, tamr_project: Project) -> List[AttributeMapping]:
+    """Get all attribute mappings of a Tamr project
+
+    Args:
+        tamr_project: Tamr project
+
+    Returns:
+        The attribute mappings of the project
+
+    Raises:
+        requests.HTTPError: If an HTTP error is encountered.
+    """
+    url = str(tamr_project.url) + "/attributeMappings"
+    r = session.get(url=url)
+
+    data = response.successful(r).json()
+    mapping_list = []
+    attribute_memo: Dict[URL, Attribute] = {}
+    for mapping_data in data:
+        mapping, attribute_memo = _get(
+            session,
+            tamr_project.url.instance,
+            mapping_data,
+            attribute_memo=attribute_memo,
+        )
+        mapping_list.append(mapping)
+    return mapping_list
+
+
+def _get(
+    session: Session,
+    instance: Instance,
+    data: JsonDict,
+    *,
+    attribute_memo: Optional[Dict[URL, Attribute]] = None
+) -> Tuple[AttributeMapping, Dict[URL, Attribute]]:
+    """Construct an attribute mapping from server response
+
+    This is a utility function used by `attribute_mapping.get_all`. When an attribute is
+    fetched, all other attributes in its dataset are also retrieved and stored in a
+    dictionary to limit the number of requests made to the server
+
+    Args:
+        instance: A Tamr instance
+        data: The JSON body of the server response retrieve a project's attribute mappings
+        attribute_memo: Dictionary of fetched attributes used to avoid redundant requests
+
+    Returns:
+        The attribute mapping and updated memo
+    """
+    if attribute_memo is None:
+        attribute_memo = {}
+    cp = deepcopy(data)
+    input_attribute_url = URL(instance=instance, path=cp["relativeInputAttributeId"])
+    unified_attribute_url = URL(
+        instance=instance, path=cp["relativeUnifiedAttributeId"]
+    )
+
+    if input_attribute_url not in attribute_memo:
+        attr_dataset = dataset.by_resource_id(
+            session, instance, cp["relativeInputAttributeId"].split("/")[1]
+        )
+        attribute_memo = {
+            **attribute_memo,
+            **{attr.url: attr for attr in dataset.attributes(session, attr_dataset)},
+        }
+    if unified_attribute_url not in attribute_memo:
+        attr_dataset = dataset.by_resource_id(
+            session, instance, cp["relativeUnifiedAttributeId"].split("/")[1]
+        )
+        attribute_memo = {
+            **attribute_memo,
+            **{attr.url: attr for attr in dataset.attributes(session, attr_dataset)},
+        }
+
+    return (
+        AttributeMapping(
+            url=URL(instance=instance, path=cp["relativeId"]),
+            input_attribute=attribute_memo[input_attribute_url],
+            unified_attribute=attribute_memo[unified_attribute_url],
+        ),
+        attribute_memo,
+    )
+
+
+def delete(session: Session, attribute_mapping: AttributeMapping):
+    """Delete an existing attribute mapping
+
+    Args:
+        attribute_mapping: Existing attribute mapping to delete
+
+    Raises:
+        attribute_mapping.NotFound: If no attribute mapping could be found at the specified URL.
+            Corresponds to a 404 HTTP error.
+        requests.HTTPError: If any other HTTP error is encountered.
+    """
+    r = session.delete(str(attribute_mapping.url))
+    if r.status_code == 404:
+        raise NotFound(str(attribute_mapping.url))
+    response.successful(r)

--- a/tests/tamr_client/fake.py
+++ b/tests/tamr_client/fake.py
@@ -180,6 +180,14 @@ def golden_records_project() -> tc.GoldenRecordsProject:
     return golden_records_project
 
 
+def schema_mapping_project() -> tc.SchemaMappingProject:
+    url = tc.URL(path="projects/4")
+    schema_mapping_project = tc.SchemaMappingProject(
+        url, name="Project 4", description="A Schema Mapping Project"
+    )
+    return schema_mapping_project
+
+
 def transforms() -> tc.Transformations:
     return tc.Transformations(
         input_scope=[
@@ -197,4 +205,18 @@ def attribute() -> tc.Attribute:
         type=tc.attribute.type.DEFAULT,
         description="Synthetic row number",
         is_nullable=False,
+    )
+
+
+def attribute_mapping() -> tc.AttributeMapping:
+    return tc.AttributeMapping(
+        url=tc.URL(path="projects/4/attributeMappings/123-456"),
+        input_attribute=attribute(),
+        unified_attribute=tc.Attribute(
+            url=tc.URL(path="datasets/2/attributes/SourceRowNum"),
+            name="RowNum",
+            type=tc.attribute.type.DEFAULT,
+            description="Synthetic row number",
+            is_nullable=False,
+        ),
     )

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create.json
@@ -1,0 +1,69 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/4/attributeMappings",
+            "json": {
+                "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum"
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "id": "unify://unified-data/v1/projects/4/attributeMappings/123-456",
+                "relativeId": "projects/4/attributeMappings/123-456",
+                "inputAttributeId": "unify://unified-data/v1/datasets/1/attributes/RowNum",
+                "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                "inputDatasetName": "dataset.csv",
+                "inputAttributeName": "RowNum",
+                "unifiedAttributeId": "unify://unified-data/v1/datasets/2/attributes/SourceRowNum",
+                "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum",
+                "unifiedDatasetName": "Project 4_unified_dataset",
+                "unifiedAttributeName": "SourceRowNum"
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1/attributes/RowNum"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "name": "RowNum",
+                "description": "Synthetic row number",
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    }
+                },
+                "isNullable": false
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/2/attributes/SourceRowNum"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "name": "SourceRowNum",
+                "description": "Synthetic row number",
+                "type": {
+                    "baseType": "ARRAY",
+                    "innerType": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    }
+                },
+                "isNullable": false
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_already_exists.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_already_exists.json
@@ -1,0 +1,15 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/4/attributeMappings",
+            "json": {
+                "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum"
+            }
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_ambiguous.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_ambiguous.json
@@ -1,0 +1,18 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/4/attributeMappings",
+            "json": {
+                "relativeInputAttributeId": "datasets/1/attributes/BadAttribute",
+                "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum"
+            }
+        },
+        "response": {
+            "status": 400,
+            "json": {
+                "message": "Mapping change from attribute AttributeId{name=BadAttribute, datasetName=dataset.csv} to unified attribute SourceRowNum is invalid"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_dataset_not_found.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_dataset_not_found.json
@@ -1,0 +1,18 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/4/attributeMappings",
+            "json": {
+                "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                "relativeUnifiedAttributeId": "datasets/9/attributes/SourceRowNum"
+            }
+        },
+        "response": {
+            "status": 404,
+            "json": {
+                "message": "Dataset with id 9 not found."
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_project_not_found.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_create_project_not_found.json
@@ -1,0 +1,18 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/9/attributeMappings",
+            "json": {
+                "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum"
+            }
+        },
+        "response": {
+            "status": 404,
+            "json": {
+                "message": "com.tamr.persist.client.exceptions.PersistenceNotFound: Could not find id '9' on persistence namespace 'projects'"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_delete.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_delete.json
@@ -1,0 +1,11 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "projects/4/attributeMappings/123-456"
+        },
+        "response": {
+            "status": 204
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_delete_not_found.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_delete_not_found.json
@@ -1,0 +1,14 @@
+[
+    {
+        "request": {
+            "method": "DELETE",
+            "path": "projects/4/attributeMappings/000-000"
+        },
+        "response": {
+            "status": 404,
+            "json": {
+                "message": "No result found"
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_get_all.json
+++ b/tests/tamr_client/fake_json/schema_mapping/test_attribute_mapping/test_get_all.json
@@ -1,0 +1,159 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/4/attributeMappings"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "id": "unify://unified-data/v1/projects/4/attributeMappings/123-456",
+                    "relativeId": "projects/4/attributeMappings/123-456",
+                    "inputAttributeId": "unify://unified-data/v1/datasets/1/attributes/RowNum",
+                    "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                    "inputDatasetName": "dataset.csv",
+                    "inputAttributeName": "RowNum",
+                    "unifiedAttributeId": "unify://unified-data/v1/datasets/2/attributes/SourceRowNum",
+                    "relativeUnifiedAttributeId": "datasets/2/attributes/SourceRowNum",
+                    "unifiedDatasetName": "Project 4_unified_dataset",
+                    "unifiedAttributeName": "SourceRowNum"
+                },
+                {
+                    "id": "unify://unified-data/v1/projects/4/attributeMappings/890-567",
+                    "relativeId": "projects/4/attributeMappings/890-567",
+                    "inputAttributeId": "unify://unified-data/v1/datasets/1/attributes/RowNum",
+                    "relativeInputAttributeId": "datasets/1/attributes/RowNum",
+                    "inputDatasetName": "dataset.csv",
+                    "inputAttributeName": "RowNum",
+                    "unifiedAttributeId": "unify://unified-data/v1/datasets/2/attributes/OtherSourceRowNum",
+                    "relativeUnifiedAttributeId": "datasets/2/attributes/OtherSourceRowNum",
+                    "unifiedDatasetName": "Project 4_unified_dataset",
+                    "unifiedAttributeName": "OtherSourceRowNum"
+                }
+            ]
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/1",
+                "externalId": "number 1",
+                "name": "dataset 1 name",
+                "description": "dataset 1 description",
+                "version": "dataset 1 version",
+                "keyAttributeNames": [
+                    "tamr_id"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 1 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 1 modified version"
+                },
+                "relativeId": "datasets/1",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/1/attributes"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "name": "RowNum",
+                    "description": "Synthetic row number",
+                    "type": {
+                        "baseType": "ARRAY",
+                        "innerType": {
+                            "baseType": "STRING",
+                            "attributes": []
+                        }
+                    },
+                    "isNullable": false
+                }
+            ]
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/2"
+        },
+        "response": {
+            "status": 200,
+            "json": {
+                "id": "unify://unified-data/v1/datasets/2",
+                "externalId": "number 1",
+                "name": "dataset 2 name",
+                "description": "dataset 2 description",
+                "version": "dataset 2 version",
+                "keyAttributeNames": [
+                    "tamr_id"
+                ],
+                "tags": [],
+                "created": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.636Z",
+                    "version": "dataset 2 created version"
+                },
+                "lastModified": {
+                    "username": "admin",
+                    "time": "2018-09-10T16:06:20.851Z",
+                    "version": "dataset 2 modified version"
+                },
+                "relativeId": "datasets/2",
+                "upstreamDatasetIds": []
+            }
+        }
+    },
+    {
+        "request": {
+            "method": "GET",
+            "path": "datasets/2/attributes"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "name": "SourceRowNum",
+                    "description": "Synthetic row number",
+                    "type": {
+                        "baseType": "ARRAY",
+                        "innerType": {
+                            "baseType": "STRING",
+                            "attributes": []
+                        }
+                    },
+                    "isNullable": false
+                },
+                {
+                    "name": "OtherSourceRowNum",
+                    "description": "Synthetic row number",
+                    "type": {
+                        "baseType": "ARRAY",
+                        "innerType": {
+                            "baseType": "STRING",
+                            "attributes": []
+                        }
+                    },
+                    "isNullable": false
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/schema_mapping/test_attribute_mapping.py
+++ b/tests/tamr_client/schema_mapping/test_attribute_mapping.py
@@ -1,0 +1,160 @@
+import pytest
+
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_create():
+    s = fake.session()
+    project = fake.schema_mapping_project()
+    input_attribute = fake.attribute()
+    unified_attribute = _unified_attribute
+
+    mapping = tc.schema_mapping.attribute_mapping.create(
+        s,
+        project,
+        input_attribute=input_attribute,
+        unified_attribute=unified_attribute,
+    )
+    assert isinstance(mapping, tc.AttributeMapping)
+    assert mapping.input_attribute == input_attribute
+    assert mapping.unified_attribute == unified_attribute
+
+
+@fake.json
+def test_create_already_exists():
+    s = fake.session()
+    project = fake.schema_mapping_project()
+    input_attribute = fake.attribute()
+    unified_attribute = _unified_attribute
+
+    with pytest.raises(tc.schema_mapping.attribute_mapping.AlreadyExists):
+        tc.schema_mapping.attribute_mapping.create(
+            s,
+            project,
+            input_attribute=input_attribute,
+            unified_attribute=unified_attribute,
+        )
+
+
+@fake.json
+def test_create_ambiguous():
+    s = fake.session()
+    project = fake.schema_mapping_project()
+    input_attribute = tc.Attribute(
+        url=tc.URL(path="datasets/1/attributes/BadAttribute"),
+        name="BadAttribute",
+        type=tc.attribute.type.DEFAULT,
+        description="Not an existing attribute",
+        is_nullable=False,
+    )
+    unified_attribute = _unified_attribute
+
+    with pytest.raises(tc.schema_mapping.attribute_mapping.Ambiguous):
+        tc.schema_mapping.attribute_mapping.create(
+            s,
+            project,
+            input_attribute=input_attribute,
+            unified_attribute=unified_attribute,
+        )
+
+
+@fake.json
+def test_create_dataset_not_found():
+    s = fake.session()
+    project = fake.schema_mapping_project()
+    input_attribute = fake.attribute()
+    unified_attribute = tc.Attribute(
+        url=tc.URL(path="datasets/9/attributes/SourceRowNum"),
+        name="SourceRowNum",
+        type=tc.attribute.type.DEFAULT,
+        description="Synthetic row number",
+        is_nullable=False,
+    )
+
+    with pytest.raises(tc.dataset.NotFound):
+        tc.schema_mapping.attribute_mapping.create(
+            s,
+            project,
+            input_attribute=input_attribute,
+            unified_attribute=unified_attribute,
+        )
+
+
+@fake.json
+def test_create_project_not_found():
+    s = fake.session()
+    project = tc.SchemaMappingProject(
+        tc.URL(path="projects/9"),
+        name="Project 4",
+        description="A nonexistent Schema Mapping Project",
+    )
+    input_attribute = fake.attribute()
+    unified_attribute = _unified_attribute
+
+    with pytest.raises(tc.project.NotFound):
+        tc.schema_mapping.attribute_mapping.create(
+            s,
+            project,
+            input_attribute=input_attribute,
+            unified_attribute=unified_attribute,
+        )
+
+
+@fake.json
+def test_get_all():
+    s = fake.session()
+    project = fake.schema_mapping_project()
+
+    mappings = tc.schema_mapping.attribute_mapping.get_all(s, project)
+
+    assert len(mappings) == 2
+
+    mapping_1 = mappings[0]
+    assert isinstance(mapping_1, tc.AttributeMapping)
+    assert mapping_1.input_attribute == fake.attribute()
+    assert mapping_1.unified_attribute == _unified_attribute
+
+    mapping_2 = mappings[1]
+    assert isinstance(mapping_2, tc.AttributeMapping)
+    assert mapping_2.input_attribute == fake.attribute()
+    assert mapping_2.unified_attribute == _unified_attribute_2
+
+
+@fake.json
+def test_delete():
+    s = fake.session()
+    mapping = fake.attribute_mapping()
+
+    tc.schema_mapping.attribute_mapping.delete(s, mapping)
+
+
+@fake.json
+def test_delete_not_found():
+    s = fake.session()
+    bad_mapping = tc.AttributeMapping(
+        url=tc.URL(path="projects/4/attributeMappings/000-000"),
+        input_attribute=fake.attribute(),
+        unified_attribute=_unified_attribute,
+    )
+
+    with pytest.raises(tc.schema_mapping.attribute_mapping.NotFound):
+        tc.schema_mapping.attribute_mapping.delete(s, bad_mapping)
+
+
+_unified_attribute = tc.Attribute(
+    url=tc.URL(path="datasets/2/attributes/SourceRowNum"),
+    name="SourceRowNum",
+    type=tc.attribute.type.DEFAULT,
+    description="Synthetic row number",
+    is_nullable=False,
+)
+
+_unified_attribute_2 = tc.Attribute(
+    url=tc.URL(path="datasets/2/attributes/OtherSourceRowNum"),
+    name="OtherSourceRowNum",
+    type=tc.attribute.type.DEFAULT,
+    description="Synthetic row number",
+    is_nullable=False,
+)


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds the `AttributeMapping` dataclass and functions for creating and deleting, as well as getting all attribute mappings from a project.

Important note: This implementation memo-izes fetched `Attributes` when making the `get_all` call.  This should probably be inspected closely.

Open questions:
- Should this dataclass live in `tamr_client._types.project`? (currently here)
- Should this module live at `tamr_client.schema_mapping.attribute_mapping`? (currently here)
  - If so, should it be hoisted to be accessible at `tamr_client.attribute_mapping`? (currently not happening)

Closes #479 

## 💻 Examples

```python
import tamr_client as tc

my_project = Project(...)  # my Tamr project
my_input_attr = Attribute(...)  # an existing attribute of an input dataset of `project`
my_unified_attr = Attribute(...)  # an existing attribute of the unified dataset of `project`

# Create a new attribute mapping
new_attr_mapping = tc.schema_mapping.attribute_mapping.create(my_project, input_attribute=my_input_attr, unified_attribute=my_unified_attr)

# Get all attribute mappings of my project
all_attr_mappings =  tc.schema_mapping.attribute_mapping.get_all(my_project)  # this is a list
print(new_attr_mapping in all_attr_mappings)  # my new mapping should be in there

# Delete my attribute mapping
tc.schema_mapping.attribute_mapping.delete(new_attr_mapping)

# Extension: I want to completely unmap `my_input_attr`
for mapping in tc.schema_mapping.attribute_mapping.get_all(my_project):
    if mapping.input_attribute_url == my_input_attr.url:
        tc.schema_mapping.attribute_mapping.delete(mapping)
```

## ✔️ PR Todo

- [x] Testing for this change
- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
