### PR TITLE
TC: Fix record.stream to be a generator

### DIFF
--- a/tamr_client/dataset/record.py
+++ b/tamr_client/dataset/record.py
@@ -148,7 +148,7 @@ def stream(session: Session, dataset: AnyDataset) -> Iterator[JsonDict]:
         Python generator yielding records
     """
     with session.get(str(dataset.url) + "/records", stream=True) as r:
-        return response.ndjson(r)
+        yield from response.ndjson(r)
 
 
 def delete_all(session: Session, dataset: AnyDataset):


### PR DESCRIPTION

# ↪️ Pull Request

Fixes an issue where records could not be streamed because `record.stream` returned an empty generator, when it should have been a generator itself.

Closes #481 

## ✔️ PR Todo

- [x] Testing for this change
- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings
