### PR TITLE
TC: Add a catch-all project dataclass to handle project types not explicitly defined

### DIFF
--- a/docs/beta/project.rst
+++ b/docs/beta/project.rst
@@ -1,6 +1,8 @@
 Project
 =======
 
+.. autoclass:: tamr_client.UnknownProject
+
 .. autofunction:: tamr_client.project.by_resource_id
 .. autofunction:: tamr_client.project.by_name
 .. autofunction:: tamr_client.project.get_all

--- a/tamr_client/__init__.py
+++ b/tamr_client/__init__.py
@@ -35,6 +35,7 @@ from tamr_client._types import (
     SubAttribute,
     Transformations,
     UnifiedDataset,
+    UnknownProject,
     URL,
     UsernamePasswordAuth,
 )

--- a/tamr_client/_types/__init__.py
+++ b/tamr_client/_types/__init__.py
@@ -27,6 +27,7 @@ from tamr_client._types.project import (
     MasteringProject,
     Project,
     SchemaMappingProject,
+    UnknownProject,
 )
 from tamr_client._types.restore import Restore
 from tamr_client._types.session import Session

--- a/tamr_client/_types/project.py
+++ b/tamr_client/_types/project.py
@@ -72,6 +72,27 @@ class GoldenRecordsProject:
     description: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class UnknownProject:
+    """A Tamr project of an unrecognized type
+
+    See https://docs.tamr.com/reference/the-project-object
+
+    Args:
+        url
+        name
+        description
+    """
+
+    url: URL
+    name: str
+    description: Optional[str] = None
+
+
 Project = Union[
-    CategorizationProject, MasteringProject, SchemaMappingProject, GoldenRecordsProject
+    CategorizationProject,
+    MasteringProject,
+    SchemaMappingProject,
+    GoldenRecordsProject,
+    UnknownProject,
 ]

--- a/tamr_client/project.py
+++ b/tamr_client/project.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple, Union
 
 from tamr_client import response
-from tamr_client._types import Instance, JsonDict, Project, Session, URL
+from tamr_client._types import Instance, JsonDict, Project, Session, UnknownProject, URL
 from tamr_client.categorization import project as categorization_project
 from tamr_client.exception import TamrClientException
 from tamr_client.golden_records import project as golden_records_project
@@ -110,7 +110,9 @@ def _from_json(url: URL, data: JsonDict) -> Project:
     elif proj_type == "GOLDEN_RECORDS":
         return golden_records_project._from_json(url, data)
     else:
-        raise ValueError(f"Unrecognized project type '{proj_type}' in {repr(data)}")
+        return UnknownProject(
+            url, name=data["name"], description=data.get("description")
+        )
 
 
 def _create(

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -132,6 +132,16 @@ def test_create_project_already_exists():
 def test_from_json_unrecognized_project_type():
     instance = fake.instance()
     url = tc.URL("project/1", instance)
-    data: tc._types.JsonDict = {"type": "NOT_A_PROJECT_TYPE"}
-    with pytest.raises(ValueError):
-        tc.project._from_json(url, data)
+    data: tc._types.JsonDict = {
+        "id": "unify://unified-data/v1/projects/1",
+        "name": "project 1",
+        "description": "A project of unknown type",
+        "type": "UNKNOWN",
+        "unifiedDatasetName": "",
+        "relativeId": "projects/1",
+        "externalId": "58bdbe72-3c08-427d-97bd-45b16d92c79c",
+    }
+    project = tc.project._from_json(url, data)
+    assert isinstance(project, tc.UnknownProject)
+    assert project.name == "project 1"
+    assert project.description == "A project of unknown type"


### PR DESCRIPTION
# ↪️ Pull Request

Closes #480

Docs screenshot: ![Screen Shot 2021-02-05 at 1 39 03 PM](https://user-images.githubusercontent.com/39866163/107075001-84d28f80-67b7-11eb-9191-64d3372a1374.png)

## ✔️ PR Todo

- [x] Testing for this change
- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/master/docs) + docstrings

