### PR TITLE
ci(release): do not use pip to install poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - name: Install poetry and toml-cli
+      - name: Install poetry
+        uses: snok/install-poetry@v1.1.1
+        with:
+          version: 1.1.4
+      - name: Install toml-cli
         run: |
           pip install --upgrade pip
-          pip install poetry==1.1.4
           pip install toml-cli==0.1.3
       - name: Install npm
         uses: actions/setup-node@v2


### PR DESCRIPTION
# ↪️ Pull Request

The poetry docs explicitly warn against using pip for installation. See
https://python-poetry.org/docs/#installing-with-pip. Instead, we'll use a Github Action tailor-made
for installing poetry.