### PR TITLE
docs(tuc): add detail to passing json body in custom endpoint documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,6 @@ pandas==1.0.5
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
 sphinx-autodoc-typehints==1.11.0
-Sphinx==3.1.1
+Sphinx==3.5.4
 toml==0.10.0
 .

--- a/docs/user-guide/advanced-usage.md
+++ b/docs/user-guide/advanced-usage.md
@@ -53,6 +53,16 @@ methods:
 response = tamr.get('relative/path/to/resource')
 ```
 
+Request headers and data can be supplied by passing dictionaries or lists with the `headers` and `json` arguments:
+
+```python
+# e.g. `post` with headers and data
+headers = {...}
+body = {...}
+
+response = tamr.post('relative/path/to/resource', headers=headers, json=body) 
+``` 
+
 ### Custom Host / Port / Base API path
 
 If you need to repeatedly send requests to another port or base API path (i.e. not `/api/versioned/v1/`), you can simply instantiate a different client.


### PR DESCRIPTION
# ↪️ Pull Request
This PR adds a section to the custom endpoint documentation, clarifying how json request bodies can be passed using the `post`/`put` methods inherited from the `requests` library.

Closes #353 

## 💻 Screenshot of Change

![image](https://user-images.githubusercontent.com/39866163/114735097-da28a100-9d12-11eb-8510-1828d6fda986.png)

## ✔️ PR Todo

- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/main/docs) + docstrings
