### PR TITLE
Use session auth token cookie to minimize re-auth events

### DIFF
--- a/tamr_client/_types/session.py
+++ b/tamr_client/_types/session.py
@@ -1,3 +1,48 @@
+from typing import Optional
+
 import requests
 
-Session = requests.Session
+from tamr_client._types.auth import UsernamePasswordAuth
+
+
+class Session(requests.Session):
+    def __init__(self):
+        super(self.__class__, self).__init__()
+        self._stored_auth: Optional[UsernamePasswordAuth] = None
+
+    def request(self, *args, **kwargs):
+        # signature of `requests` requires not naming positional args
+        response = super(self.__class__, self).request(*args, **kwargs)
+        if response.status_code == 401 and "credentials" in response.text.lower():
+            first_response = response
+            self._set_auth_cookie(args[1])
+            response = super(self.__class__, self).request(*args, **kwargs)
+            if response.status_code == 401 and "credentials" in response.text.lower():
+                # Login credentials are bad, return original response
+                response = first_response
+        return response
+
+    def _set_auth_cookie(self, parent_url: str):
+        """Fetch and store an auth token for the given client configuration"""
+        # No-op if _stored_auth is None
+        if self._stored_auth is None:
+            return
+
+        # Fetch auth token and store as cookie
+        socket_address = parent_url.split("/api/")[0]
+        r = self.post(
+            socket_address + "/api/versioned/v1/instance:login",
+            json={
+                "username": self._stored_auth.username,
+                "password": self._stored_auth.password,
+            },
+        )
+        if r.status_code == 200:
+            auth_token = r.json()["token"]
+            self.cookies.set("authToken", auth_token)  # TODO: Set domain for security
+            # Clear session auth if cookie is retrieved
+            self.auth = None
+        else:
+            # Set session auth from client auth in case it has been cleared
+            # Allow the following call to pass credentials in header
+            self.auth = self._stored_auth

--- a/tamr_client/session.py
+++ b/tamr_client/session.py
@@ -1,14 +1,13 @@
-import requests
-
 from tamr_client._types import Session
+from tamr_client._types.auth import UsernamePasswordAuth
 
 
-def from_auth(auth: requests.auth.HTTPBasicAuth) -> Session:
+def from_auth(auth: UsernamePasswordAuth) -> Session:
     """Create a new authenticated session
 
     Args:
         auth: Authentication
     """
-    s = requests.Session()
-    s.auth = auth
+    s = Session()
+    s._stored_auth = auth
     return s

--- a/tests/tamr_client/fake.py
+++ b/tests/tamr_client/fake.py
@@ -132,8 +132,12 @@ def json(test_fn):
     return wrapper
 
 
-def session() -> tc.Session:
-    auth = tc.UsernamePasswordAuth("username", "password")
+def username_password_auth() -> tc.UsernamePasswordAuth:
+    return tc.UsernamePasswordAuth("username", "password")
+
+
+def session() -> tc._types.Session:
+    auth = username_password_auth()
     s = tc.session.from_auth(auth)
     return s
 

--- a/tests/tamr_client/fake_json/test_session/test_bad_credentials.json
+++ b/tests/tamr_client/fake_json/test_session/test_bad_credentials.json
@@ -1,0 +1,28 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 401,
+      "body": "Credentials are required to access this resource."
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "url": "http://localhost/api/versioned/v1/instance:login",
+      "body": {
+        "username": "username",
+        "password": "password"
+      }
+    },
+    "response": {
+      "status": 405,
+      "json": {
+        "message": "HTTP 405 Method Not Allowed"
+      }
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_session/test_get_auth_cookie.json
+++ b/tests/tamr_client/fake_json/test_session/test_get_auth_cookie.json
@@ -1,0 +1,73 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 401,
+      "body": "Credentials are required to access this resource."
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "url": "http://localhost/api/versioned/v1/instance:login",
+      "body": {
+        "username": "username",
+        "password": "password"
+      }
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "token": "auth_token_string_value",
+        "username": "username"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 200,
+      "json": [
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+          "relativeId": "2020-08-17_21-32-10-961",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+          "state": "CANCELED",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-32-10-961",
+          "lastModified": "2020-08-17_21-51-57-600"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-01-205",
+          "relativeId": "2020-08-17_21-58-01-205",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-01-205",
+          "state": "RUNNING",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-58-01-205",
+          "lastModified": "2020-08-17_21-58-01-351"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-45-062",
+          "relativeId": "2020-08-17_21-58-45-062",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-45-062",
+          "state": "FAILED",
+          "stage": "",
+          "errorMessage": "A system operation is already in progress",
+          "created": "2020-08-17_21-58-45-062",
+          "lastModified": "2020-08-17_21-58-45-249"
+        }
+      ]
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_session/test_missing_api.json
+++ b/tests/tamr_client/fake_json/test_session/test_missing_api.json
@@ -1,0 +1,72 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 401,
+      "body": "Credentials are required to access this resource."
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "url": "http://localhost/api/versioned/v1/instance:login",
+      "body": {
+        "username": "username",
+        "password": "password"
+      }
+    },
+    "response": {
+      "status": 404,
+      "json": {
+        "message": "HTTP 404 Not Found"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 200,
+      "json": [
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+          "relativeId": "2020-08-17_21-32-10-961",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+          "state": "CANCELED",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-32-10-961",
+          "lastModified": "2020-08-17_21-51-57-600"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-01-205",
+          "relativeId": "2020-08-17_21-58-01-205",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-01-205",
+          "state": "RUNNING",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-58-01-205",
+          "lastModified": "2020-08-17_21-58-01-351"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-45-062",
+          "relativeId": "2020-08-17_21-58-45-062",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-45-062",
+          "state": "FAILED",
+          "stage": "",
+          "errorMessage": "A system operation is already in progress",
+          "created": "2020-08-17_21-58-45-062",
+          "lastModified": "2020-08-17_21-58-45-249"
+        }
+      ]
+    }
+  }
+]

--- a/tests/tamr_client/fake_json/test_session/test_refresh_auth_cookie.json
+++ b/tests/tamr_client/fake_json/test_session/test_refresh_auth_cookie.json
@@ -1,0 +1,73 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 401,
+      "body": "Credentials are required to access this resource."
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "url": "http://localhost/api/versioned/v1/instance:login",
+      "body": {
+        "username": "username",
+        "password": "password"
+      }
+    },
+    "response": {
+      "status": 200,
+      "json": {
+        "token": "auth_token_string_value",
+        "username": "username"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "backups"
+    },
+    "response": {
+      "status": 200,
+      "json": [
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-32-10-961",
+          "relativeId": "2020-08-17_21-32-10-961",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-32-10-961",
+          "state": "CANCELED",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-32-10-961",
+          "lastModified": "2020-08-17_21-51-57-600"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-01-205",
+          "relativeId": "2020-08-17_21-58-01-205",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-01-205",
+          "state": "RUNNING",
+          "stage": "",
+          "errorMessage": "",
+          "created": "2020-08-17_21-58-01-205",
+          "lastModified": "2020-08-17_21-58-01-351"
+        },
+        {
+          "id": "unify://unified-data/v1/backups/2020-08-17_21-58-45-062",
+          "relativeId": "2020-08-17_21-58-45-062",
+          "user": "admin",
+          "backupPath": "/home/ubuntu/tamr/backups/2020-08-17_21-58-45-062",
+          "state": "FAILED",
+          "stage": "",
+          "errorMessage": "A system operation is already in progress",
+          "created": "2020-08-17_21-58-45-062",
+          "lastModified": "2020-08-17_21-58-45-249"
+        }
+      ]
+    }
+  }
+]

--- a/tests/tamr_client/test_session.py
+++ b/tests/tamr_client/test_session.py
@@ -1,0 +1,126 @@
+from functools import partial
+import json
+
+import pytest
+import requests
+import responses
+
+import tamr_client as tc
+from tests.tamr_client import fake
+
+
+@fake.json
+def test_get_auth_cookie():
+    auth = fake.username_password_auth()
+    s = fake.session()
+    instance = fake.instance()
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert len(s.cookies.keys()) == 0
+
+    tc.backup.get_all(session=s, instance=instance)
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert s.cookies.get("authToken") == "auth_token_string_value"
+
+
+@fake.json
+def test_refresh_auth_cookie():
+    auth = fake.username_password_auth()
+    s = fake.session()
+    instance = fake.instance()
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert len(s.cookies.keys()) == 0
+
+    tc.backup.get_all(session=s, instance=instance)
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert s.cookies.get("authToken") == "auth_token_string_value"
+
+
+@fake.json
+def test_bad_credentials():
+    auth = fake.username_password_auth()
+    s = fake.session()
+    instance = fake.instance()
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert len(s.cookies.keys()) == 0
+    s.cookies.set("authToken", "expired_auth_token")
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        tc.backup.get_all(session=s, instance=instance)
+
+
+@fake.json
+def test_missing_api():
+    auth = fake.username_password_auth()
+    s = fake.session()
+    instance = fake.instance()
+
+    assert s.auth is None
+    assert s._stored_auth == auth
+    assert len(s.cookies.keys()) == 0
+
+    tc.backup.get_all(session=s, instance=instance)
+
+    assert s.auth == auth
+
+
+@responses.activate  # TODO: Can this request header checking be done with fake.json?
+def test_request_headers():
+    def create_callback(request, snoop, status, response_body):
+        snoop["headers"] = request.headers
+        return status, {}, json.dumps(response_body)
+
+    auth_endpoint = "http://localhost/api/versioned/v1/instance:login"
+    endpoint = "http://localhost/api/versioned/v1/backups"
+    snoop_dict_1: tc._types.JsonDict = {}
+    responses.add_callback(
+        responses.GET,
+        endpoint,
+        partial(
+            create_callback,
+            snoop=snoop_dict_1,
+            status=401,
+            response_body="Credentials are required to access this resource.",
+        ),
+    )
+
+    snoop_dict_2: tc._types.JsonDict = {}
+    responses.add_callback(
+        responses.POST,
+        auth_endpoint,
+        partial(
+            create_callback, snoop=snoop_dict_2, status=200, response_body=auth_json,
+        ),
+    )
+
+    snoop_dict_3: tc._types.JsonDict = {}
+    responses.add_callback(
+        responses.GET,
+        endpoint,
+        partial(create_callback, snoop=snoop_dict_3, status=200, response_body={},),
+    )
+
+    s = fake.session()
+    instance = fake.instance()
+    tc.backup.get_all(session=s, instance=instance)
+
+    # No credentials in any call
+    assert "Authorization" not in snoop_dict_1["headers"]
+    assert "Authorization" not in snoop_dict_2["headers"]
+    assert "Authorization" not in snoop_dict_3["headers"]
+    # No cookie in first call
+    assert "Cookie" not in snoop_dict_1["headers"]
+    # Valid cookie passed in second call
+    assert snoop_dict_3["headers"]["Cookie"] == f'authToken={auth_json["token"]}'
+
+
+auth_json = {"token": "auth_token_string_value", "username": "user"}

--- a/tests/unit/test_requests_session.py
+++ b/tests/unit/test_requests_session.py
@@ -1,8 +1,19 @@
+from functools import partial
+import json
+
+import pytest
 import requests
 import responses
 
 from tamr_unify_client import Client
-from tamr_unify_client.auth import UsernamePasswordAuth
+from tamr_unify_client.auth import TokenAuth, UsernamePasswordAuth
+
+auth_json = {
+    "token": "auth_token_string_value",
+    "username": "username",
+}
+
+expired_auth_json = {"token": "expired_auth_token", "user": "username"}
 
 
 @responses.activate
@@ -28,3 +39,135 @@ def test_request_session_cookie():
     assert req.url.endswith("test")
     assert req.headers.get("Cookie") is not None
     assert "test_cookie=" in req.headers.get("Cookie")
+
+
+@responses.activate
+def test_auth_cookie():
+    def create_callback(request, snoop, status, response_body):
+        snoop["headers"] = request.headers
+        snoop["body"] = json.loads(request.body) if request.body is not None else None
+        return status, {}, json.dumps(response_body)
+
+    auth_endpoint = "http://localhost:9100/api/versioned/v1/instance:login"
+    snoop_dict = {}
+    responses.add_callback(
+        responses.POST,
+        auth_endpoint,
+        partial(create_callback, snoop=snoop_dict, status=200, response_body=auth_json),
+    )
+
+    auth = UsernamePasswordAuth("user", "password")
+    client = Client(auth, store_auth_cookie=True)
+
+    assert client.auth == auth
+    assert client.session.auth is None
+    assert snoop_dict["body"] == {"username": "user", "password": "password"}
+    assert client.session.cookies.get("authToken") == auth_json["token"]
+
+    # Ensure credentials are not passed on subsequent requests
+    endpoint = "http://localhost:9100/api/versioned/v1/test"
+    snoop_dict = {}
+    responses.add_callback(
+        responses.GET,
+        endpoint,
+        partial(create_callback, snoop=snoop_dict, status=200, response_body={}),
+    )
+
+    client.get(endpoint)
+
+    # No credentials, but valid cookie passed in second call
+    assert "Authorization" not in snoop_dict["headers"]
+    assert snoop_dict["headers"]["Cookie"] == f'authToken={auth_json["token"]}'
+
+
+@responses.activate
+def test_auth_cookie_refresh():
+    def create_callback(request, snoop, status, response_body):
+        snoop["headers"] = request.headers
+        snoop["body"] = json.loads(request.body) if request.body is not None else None
+        return status, {}, json.dumps(response_body)
+
+    # First hit auth endpoint on client creation
+    auth_endpoint = "http://localhost:9100/api/versioned/v1/instance:login"
+    snoop_dict = {}
+    responses.add_callback(
+        responses.POST,
+        auth_endpoint,
+        partial(
+            create_callback,
+            snoop=snoop_dict,
+            status=200,
+            response_body=expired_auth_json,
+        ),
+    )
+
+    auth = UsernamePasswordAuth("user", "password")
+    client = Client(auth, store_auth_cookie=True)
+
+    assert client.auth == auth
+    assert client.session.auth is None
+    assert snoop_dict["body"] == {"username": "user", "password": "password"}
+    assert client.session.cookies.get("authToken") == expired_auth_json["token"]
+
+    # Clear responses
+    responses.reset()
+
+    # Next hit target endpoint but credentials are expired
+    endpoint = "http://localhost:9100/api/versioned/v1/test"
+    snoop_dict_1 = {}
+    responses.add_callback(
+        responses.GET,
+        endpoint,
+        partial(
+            create_callback,
+            snoop=snoop_dict_1,
+            status=401,
+            response_body="Credentials are required to access this resource.",
+        ),
+    )
+
+    # Hit auth endpoint again
+    snoop_dict_2 = {}
+    responses.add_callback(
+        responses.POST,
+        auth_endpoint,
+        partial(
+            create_callback, snoop=snoop_dict_2, status=200, response_body=auth_json,
+        ),
+    )
+
+    # Finally hit target endpoint and succeed
+    snoop_dict_3 = {}
+    responses.add_callback(
+        responses.GET,
+        endpoint,
+        partial(create_callback, snoop=snoop_dict_3, status=200, response_body={}),
+    )
+
+    r = client.get(endpoint)
+    # Final response should succeed
+    assert r.status_code == 200
+    # Session should have refreshed cookie
+    assert client.auth == auth
+    assert client.session.auth is None
+    assert client.session.cookies.get("authToken") == auth_json["token"]
+
+    # Check headers from each call
+    # No credentials in any call
+    assert "Authorization" not in snoop_dict_1["headers"]
+    assert "Authorization" not in snoop_dict_2["headers"]
+    assert "Authorization" not in snoop_dict_3["headers"]
+    # Expired cookie in first call
+    assert (
+        snoop_dict_1["headers"]["Cookie"] == f'authToken={expired_auth_json["token"]}'
+    )
+    # Credentials passed to auth service
+    assert snoop_dict["body"] == {"username": "user", "password": "password"}
+    # No credentials, but valid cookie passed in second call
+    assert snoop_dict_3["headers"]["Cookie"] == f'authToken={auth_json["token"]}'
+
+
+def test_auth_cookie_token_auth_not_supported():
+    auth = TokenAuth("token")
+    with pytest.raises(TypeError):
+        Client(auth, store_auth_cookie=True)


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds the capability to fetch and store Tamr auth cookies to reuse sessions and limit the necessary number of calls to the Tamr auth service.

For TC, auth cookie fetching is done automatically whenever a request is made to the Tamr server and a valid cookie is not already stored.

For TUC, an auth cookie is fetched when a `Client` is created with the `store_auth_cookie` parameter set to `True`. It is `False` by default.  An existing `Client` without an auth cookie can be manually directed to fetch one with the method `.set_auth_cookie()`.

Closes #305 

## 💻 Examples

```python
from tamr_unify_client.auth import UsernamePasswordAuth
from tamr_unify_client.client import Client

auth = UsernamePasswordAuth("my_username", "my_password")
client = Client(auth, store_auth_cookie=True)

# OR

client = Client(auth)
client.set_auth_cookie()
```

## ✔️ PR Todo

- [x] Testing for this change
- [x] Links to related issues/PRs
- [x] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/main/docs) + docstrings
