### PR TITLE
Allow hitting API endpoints with scheme-like relative urls

### DIFF
--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -90,11 +90,12 @@ class Client:
             HTTP response from the Tamr server
         """
         # imperfect solution needed to allow passing absolute urls
-        if f"{self.host}:" in endpoint or endpoint[0] == "/":
-            url = urljoin(self.origin + self.base_path, endpoint)
-        else:
-            # prefix endpoint with "./" to handle endpoints with a colon and no other slashes
+        if endpoint.count(":") == 1 and "/" not in endpoint:
+            # prefix endpoint with "./" to handle endpoints with a colon and no slashes
             url = urljoin(self.origin + self.base_path, "./" + endpoint)
+        else:
+            # can handle with standard urljoin
+            url = urljoin(self.origin + self.base_path, endpoint)
         response = self.session.request(method, url, **kwargs)
 
         logger.info(

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional
-from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import requests
 import requests.auth
@@ -89,13 +89,12 @@ class Client:
         Returns:
             HTTP response from the Tamr server
         """
-        # imperfect solution needed to allow passing absolute urls
-        if endpoint.count(":") == 1 and "/" not in endpoint:
-            # prefix endpoint with "./" to handle endpoints with a colon and no slashes
-            url = urljoin(self.origin + self.base_path, "./" + endpoint)
+        if urlparse(endpoint).scheme != "" and urlparse(endpoint).netloc != "":
+            url = endpoint
+        elif endpoint.startswith("/"):
+            url = self.origin + endpoint
         else:
-            # can handle with standard urljoin
-            url = urljoin(self.origin + self.base_path, endpoint)
+            url = self.origin + self.base_path + endpoint
         response = self.session.request(method, url, **kwargs)
 
         logger.info(

--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -89,7 +89,12 @@ class Client:
         Returns:
             HTTP response from the Tamr server
         """
-        url = urljoin(self.origin + self.base_path, endpoint)
+        # imperfect solution needed to allow passing absolute urls
+        if f"{self.host}:" in endpoint or endpoint[0] == "/":
+            url = urljoin(self.origin + self.base_path, endpoint)
+        else:
+            # prefix endpoint with "./" to handle endpoints with a colon and no other slashes
+            url = urljoin(self.origin + self.base_path, "./" + endpoint)
         response = self.session.request(method, url, **kwargs)
 
         logger.info(

--- a/tamr_unify_client/dataset/usage.py
+++ b/tamr_unify_client/dataset/usage.py
@@ -10,7 +10,7 @@ class DatasetUsage(BaseResource):
     """
 
     @classmethod
-    def from_json(self, client, resource_json, api_path):
+    def from_json(cls, client, resource_json, api_path):
         return super().from_data(client, resource_json, api_path)
 
     @property

--- a/tests/unit/test_attribute_configuration_collection.py
+++ b/tests/unit/test_attribute_configuration_collection.py
@@ -23,7 +23,7 @@ class TestAttributeConfigurationCollection(TestCase):
     @responses.activate
     def test_by_relative_id(self):
         ac_url = "http://localhost:9100/api/versioned/v1/projects/1/attributeConfigurations/1"
-        alias = "projects/1/attributeConfigurations/"
+        alias = "projects/1/attributeConfigurations"
         ac_test = AttributeConfigurationCollection(self.tamr, alias)
         expected = self.acc_json[0]["relativeId"]
         responses.add(responses.GET, ac_url, json=self.acc_json[0])
@@ -35,7 +35,7 @@ class TestAttributeConfigurationCollection(TestCase):
     @responses.activate
     def test_by_resource_id(self):
         ac_url = "http://localhost:9100/api/versioned/v1/projects/1/attributeConfigurations/1"
-        alias = "projects/1/attributeConfigurations/"
+        alias = "projects/1/attributeConfigurations"
         ac_test = AttributeConfigurationCollection(self.tamr, alias)
         expected = self.acc_json[0]["relativeId"]
         responses.add(responses.GET, ac_url, json=self.acc_json[0])

--- a/tests/unit/test_request_absolute_endpoint.py
+++ b/tests/unit/test_request_absolute_endpoint.py
@@ -16,3 +16,26 @@ def test_request_absolute_endpoint():
     # raise a ConnectionRefused exception.
     response = client.get(endpoint)
     assert response.url == full_url
+
+
+@responses.activate
+def test_request_colon_endpoint():
+    endpoint = "instance:login"
+    full_url = f"http://localhost:9100/api/versioned/v1/{endpoint}"
+    responses.add(responses.GET, full_url, json={})
+
+    client = Client(UsernamePasswordAuth("username", "password"))
+
+    # If client does not properly handle paths, client.get() will
+    # raise a ConnectionRefused exception.
+    response = client.get(endpoint)
+    assert response.url == full_url
+
+    # Check that passing full url works
+    response = client.get(full_url)
+    assert response.url == full_url
+
+    # Check that passing absolute path url works
+    absolute_endpoint = f"/api/versioned/v1/{endpoint}"
+    response = client.get(absolute_endpoint)
+    assert response.url == full_url


### PR DESCRIPTION
# ↪️ Pull Request

Addresses an error that occurs when trying to reach the versioned API endpoints `instance:login` and `projects:import`.  Since these look like schemes, the function `urljoin` assumes they are the absolute URI.  An additional, and not ideal, change has been made to still accommodate making requests with full URIs, so long as they have the same protocol (`http`, `https`, etc.) as is configured for the client instance.

## 💻 Examples
```python
from tamr_unify_client import client
TAMR = client.Client(...)
TAMR.post("projects:import", json={...})
```
Before this PR, the underlying request would try to hit `projects:import` and fail with a `requests.exceptions.InvalidSchema` exception.  With this PR the request will succeed.

An alternative to this PR is to provide the guidance that the API endpoints of the format `abc:xyz` must be worked around by formatting with a `./`-prefix (`./abc:xyz`) or hit with and absolute URI.

## ✔️ PR Todo

- [x] Testing for this change
- [ ] Links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/main/docs) + docstrings
