### PR TITLE
Project attributes

### DIFF
--- a/docs/beta/attribute/attribute.rst
+++ b/docs/beta/attribute/attribute.rst
@@ -20,3 +20,6 @@ Exceptions
 
 .. autoclass:: tamr_client.attribute.ReservedName
   :no-inherited-members:
+
+.. autoclass:: tamr_client.attribute.CannotCreateAttributesOnUnifiedDataset
+  :no-inherited-members:

--- a/docs/beta/project.rst
+++ b/docs/beta/project.rst
@@ -6,6 +6,7 @@ Project
 .. autofunction:: tamr_client.project.by_resource_id
 .. autofunction:: tamr_client.project.by_name
 .. autofunction:: tamr_client.project.get_all
+.. autofunction:: tamr_client.project.attributes
 
 Exceptions
 ----------

--- a/tamr_client/attribute/__init__.py
+++ b/tamr_client/attribute/__init__.py
@@ -2,8 +2,10 @@ from tamr_client.attribute import sub
 from tamr_client.attribute import type
 from tamr_client.attribute._attribute import (
     _from_json,
+    _get_all_from_parent,
     AlreadyExists,
     by_resource_id,
+    CannotCreateAttributesOnUnifiedDataset,
     create,
     delete,
     NotFound,

--- a/tamr_client/dataset/_dataset.py
+++ b/tamr_client/dataset/_dataset.py
@@ -2,7 +2,6 @@
 See https://docs.tamr.com/reference/dataset-models
 """
 from copy import deepcopy
-from dataclasses import replace
 from typing import List, Optional, Tuple, Union
 
 from tamr_client import operation, response
@@ -15,7 +14,7 @@ from tamr_client._types import (
     Session,
     URL,
 )
-from tamr_client.attribute import _from_json as _attribute_from_json
+from tamr_client.attribute import _get_all_from_parent
 from tamr_client.exception import TamrClientException
 
 
@@ -136,17 +135,7 @@ def attributes(session: Session, dataset: Dataset) -> Tuple[Attribute, ...]:
     Raises:
         requests.HTTPError: If an HTTP error is encountered.
     """
-    attrs_url = replace(dataset.url, path=dataset.url.path + "/attributes")
-    r = session.get(str(attrs_url))
-    attrs_json = response.successful(r).json()
-
-    attrs = []
-    for attr_json in attrs_json:
-        id = attr_json["name"]
-        attr_url = replace(attrs_url, path=attrs_url.path + f"/{id}")
-        attr = _attribute_from_json(attr_url, attr_json)
-        attrs.append(attr)
-    return tuple(attrs)
+    return _get_all_from_parent(session, dataset)
 
 
 def materialize(session: Session, dataset: Dataset) -> Operation:

--- a/tamr_client/project.py
+++ b/tamr_client/project.py
@@ -1,7 +1,16 @@
 from typing import List, Optional, Tuple, Union
 
 from tamr_client import response
-from tamr_client._types import Instance, JsonDict, Project, Session, UnknownProject, URL
+from tamr_client._types import (
+    Attribute,
+    Instance,
+    JsonDict,
+    Project,
+    Session,
+    UnknownProject,
+    URL,
+)
+from tamr_client.attribute import _get_all_from_parent
 from tamr_client.categorization import project as categorization_project
 from tamr_client.exception import TamrClientException
 from tamr_client.golden_records import project as golden_records_project
@@ -198,3 +207,18 @@ def get_all(
         project = _from_json(project_url, project_json)
         projects.append(project)
     return tuple(projects)
+
+
+def attributes(session: Session, project: Project) -> Tuple[Attribute, ...]:
+    """Get all attributes from a project
+
+    Args:
+        project: Project containing the desired attributes
+
+    Returns:
+        The attributes for the specified project
+
+    Raises:
+        requests.HTTPError: If an HTTP error is encountered.
+    """
+    return _get_all_from_parent(session, project)

--- a/tests/tamr_client/attribute/test_attribute.py
+++ b/tests/tamr_client/attribute/test_attribute.py
@@ -177,3 +177,11 @@ def test_delete_attribute_not_found():
 
     with pytest.raises(tc.attribute.NotFound):
         tc.attribute.delete(s, attr)
+
+
+def test_create_attribute_on_unified_dataset():
+    s = fake.session()
+    dataset = fake.unified_dataset()
+
+    with pytest.raises(tc.attribute.CannotCreateAttributesOnUnifiedDataset):
+        tc.attribute.create(s, dataset, name="attr", is_nullable=False)  # type: ignore

--- a/tests/tamr_client/attribute/test_attribute.py
+++ b/tests/tamr_client/attribute/test_attribute.py
@@ -60,6 +60,38 @@ def test_create():
 
 
 @fake.json
+def test_create_project_attribute():
+    s = fake.session()
+    project = fake.mastering_project()
+
+    attrs = tuple(
+        [
+            tc.SubAttribute(
+                name=str(i),
+                is_nullable=True,
+                type=tc.attribute.type.Array(tc.attribute.type.STRING),
+            )
+            for i in range(4)
+        ]
+    )
+
+    attr = tc.attribute.create(
+        s,
+        project,
+        name="attr",
+        is_nullable=False,
+        type=tc.attribute.type.Record(attributes=attrs),
+        description="an attribute",
+    )
+
+    assert attr.name == "attr"
+    assert not attr.is_nullable
+    assert isinstance(attr.type, tc.attribute.type.Record)
+    assert attr.type.attributes == attrs
+    assert attr.description == "an attribute"
+
+
+@fake.json
 def test_update():
     s = fake.session()
     attr = fake.attribute()

--- a/tests/tamr_client/fake_json/attribute/test_attribute/test_create_project_attribute.json
+++ b/tests/tamr_client/fake_json/attribute/test_attribute/test_create_project_attribute.json
@@ -1,0 +1,119 @@
+[
+    {
+        "request": {
+            "method": "POST",
+            "path": "projects/1/attributes",
+            "json": {
+                "name": "attr",
+                "isNullable": false,
+                "type": {
+                    "baseType": "RECORD",
+                    "attributes": [
+                        {
+                            "name": "0",
+                            "isNullable": true,
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING"
+                                }
+                            }
+                        },
+                        {
+                            "name": "1",
+                            "isNullable": true,
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING"
+                                }
+                            }
+                        },
+                        {
+                            "name": "2",
+                            "isNullable": true,
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING"
+                                }
+                            }
+                        },
+                        {
+                            "name": "3",
+                            "isNullable": true,
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "description": "an attribute"
+            }
+        },
+        "response": {
+            "status": 201,
+            "json": {
+                "name": "attr",
+                "description": "an attribute",
+                "type": {
+                    "baseType": "RECORD",
+                    "attributes": [
+                        {
+                            "name": "0",
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING",
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "isNullable": true
+                        },
+                        {
+                            "name": "1",
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING",
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "isNullable": true
+                        },
+                        {
+                            "name": "2",
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING",
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "isNullable": true
+                        },
+                        {
+                            "name": "3",
+                            "type": {
+                                "baseType": "ARRAY",
+                                "innerType": {
+                                    "baseType": "STRING",
+                                    "attributes": []
+                                },
+                                "attributes": []
+                            },
+                            "isNullable": true
+                        }
+                    ]
+                },
+                "isNullable": false
+            }
+        }
+    }
+]

--- a/tests/tamr_client/fake_json/test_project/test_attributes.json
+++ b/tests/tamr_client/fake_json/test_project/test_attributes.json
@@ -1,0 +1,80 @@
+[
+    {
+        "request": {
+            "method": "GET",
+            "path": "projects/1/attributes"
+        },
+        "response": {
+            "status": 200,
+            "json": [
+                {
+                    "name": "RowNum",
+                    "description": "Synthetic row number",
+                    "type": {
+                        "baseType": "STRING",
+                        "attributes": []
+                    },
+                    "isNullable": false
+                },
+                {
+                    "name": "geom",
+                    "description": "",
+                    "type": {
+                        "baseType": "RECORD",
+                        "attributes": [
+                            {
+                                "name": "point",
+                                "type": {
+                                    "baseType": "ARRAY",
+                                    "innerType": {
+                                        "baseType": "DOUBLE",
+                                        "attributes": []
+                                    },
+                                    "attributes": []
+                                },
+                                "isNullable": true
+                            },
+                            {
+                                "name": "lineString",
+                                "type": {
+                                    "baseType": "ARRAY",
+                                    "innerType": {
+                                        "baseType": "ARRAY",
+                                        "innerType": {
+                                            "baseType": "DOUBLE",
+                                            "attributes": []
+                                        },
+                                        "attributes": []
+                                    },
+                                    "attributes": []
+                                },
+                                "isNullable": true
+                            },
+                            {
+                                "name": "polygon",
+                                "type": {
+                                    "baseType": "ARRAY",
+                                    "innerType": {
+                                        "baseType": "ARRAY",
+                                        "innerType": {
+                                            "baseType": "ARRAY",
+                                            "innerType": {
+                                                "baseType": "DOUBLE",
+                                                "attributes": []
+                                            },
+                                            "attributes": []
+                                        },
+                                        "attributes": []
+                                    },
+                                    "attributes": []
+                                },
+                                "isNullable": true
+                            }
+                        ]
+                    },
+                    "isNullable": false
+                }
+            ]
+        }
+    }
+]

--- a/tests/tamr_client/test_project.py
+++ b/tests/tamr_client/test_project.py
@@ -145,3 +145,19 @@ def test_from_json_unrecognized_project_type():
     assert isinstance(project, tc.UnknownProject)
     assert project.name == "project 1"
     assert project.description == "A project of unknown type"
+
+
+@fake.json
+def test_attributes():
+    s = fake.session()
+    project = fake.mastering_project()
+
+    attrs = tc.project.attributes(s, project)
+
+    row_num = attrs[0]
+    assert row_num.name == "RowNum"
+    assert row_num.type == tc.attribute.type.STRING
+
+    geom = attrs[1]
+    assert geom.name == "geom"
+    assert isinstance(geom.type, tc.attribute.type.Record)


### PR DESCRIPTION
# ↪️ Pull Request
Current functionality only supports accessing attributes of datasets (including as unified datasets), but projects have attributes as well.  The Tamr server requires attributes be created with project attribute endpoints rather than unified dataset attribute endpoints.

This PR updates type hinting to support the use of `Project` instances as the `parent` argument in attribute-fetching functions, and adds a check to prevent the creation of attributes in a unified dataset when creation must be done in the related project.

Also adds function `project.attributes(...)` to return all attributes of a project.

Open questions:
- The `ValueError` raised when trying to create an attribute for a unified dataset should be changed to a custom exception, but I'm not sure what to call it.
- This check is only made in the `attribute.create(...)` function.  Maybe it should be moved into the `_create` function and also implemented somehow in the `update`/`delete` functions.


## 💻 Examples

```python
import tamr_client as tc

s = tc.Session(...)
instance = tc.Instance(...)

project = tc.MasteringProject(...)
ud = tc.dataset.unified.from_project(s, project)  # has type UnifiedDataset

# Will fail
attr = tc.attribute.create(s, ud, name="my_attr", is_nullable=True)
>>> ValueError("Attributes for unified datasets must be created as attributes of the containing project")

# Will succeed
attr = tc.attribute.create(s, project, name="my_attr", is_nullable=True)

```

## ✔️ PR Todo

- [ ] Testing for this change
- [ ] Links to related issues/PRs
- [ ] Update relevant [docs](https://github.com/Datatamer/tamr-client/tree/main/docs) + docstrings
