### PR TITLE
fix(tuc): change set_auth_cookie to defer to legacy functionality on request errors

### DIFF
--- a/tamr_unify_client/client.py
+++ b/tamr_unify_client/client.py
@@ -144,8 +144,10 @@ class Client:
             "./instance:login",
             json={"username": self.auth.username, "password": self.auth.password},
         )
-        if r.status_code != 200:
-            raise Exception  # TODO: Replace with sensible handling
+        # If login request fails for any reason do not set cookie so following responses use
+        # header credentials for authentication
+        if not r.ok:
+            return
         auth_token = r.json()["token"]
         self.session.cookies.set("authToken", auth_token)  # TODO: Set domain
         # Clear session auth.  It is still accessible as self.auth if needed


### PR DESCRIPTION
# ↪️ Pull Request

Fixes an oversight in #490 that could give confusing error messages when e.g. using incorrect credentials

## ✔️ PR Todo

- [x] Links to related issues/PRs
